### PR TITLE
[HOT-FIX] Temporary remove session cart subscriber

### DIFF
--- a/src/DependencyInjection/ShopApiExtension.php
+++ b/src/DependencyInjection/ShopApiExtension.php
@@ -16,5 +16,7 @@ final class ShopApiExtension extends Extension
     {
         $config = $this->processConfiguration($this->getConfiguration([], $container), $config);
         $loader = new XmlFileLoader($container, new FileLocator(__DIR__ . '/../Resources/config'));
+
+        $loader->load('services.xml');
     }
 }

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+
+ This file is part of the Sylius package.
+
+ (c) Paweł Jędrzejewski
+
+ For the full copyright and license information, please view the LICENSE
+ file that was distributed with this source code.
+
+-->
+
+<container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+    <services>
+        <service id="sylius.listener.session_cart" class="Sylius\Bundle\CoreBundle\EventListener\SessionCartSubscriber">
+            <argument type="service" id="sylius.context.cart" />
+            <argument>_sylius.cart</argument>
+            <argument type="service" id="security.firewall.map" />
+        </service>
+    </services>
+</container>


### PR DESCRIPTION
This fix is needed to make request stateless. This is just a temporary solution because it would break Sylius Shop. 