### PR TITLE
[Config] Remove config file

### DIFF
--- a/src/Resources/config/app/config.yml
+++ b/src/Resources/config/app/config.yml
@@ -1,9 +1,0 @@
-fos_rest:
-    exception: ~
-    view:
-        formats:
-            json: true
-        empty_content: 204
-    format_listener:
-        rules:
-            - { path: '^/shop-api', priorities: ['json'], fallback_format: json, prefer_extension: true }

--- a/tests/Application/app/config/config.yml
+++ b/tests/Application/app/config/config.yml
@@ -8,8 +8,6 @@ imports:
     - { resource: "@SyliusShopBundle/Resources/config/app/config.yml" }
     - { resource: "@SyliusAdminApiBundle/Resources/config/app/config.yml" }
 
-    - { resource: "@ShopApiPlugin/Resources/config/app/config.yml" }
-
     - { resource: "security.yml" }
 
 framework:
@@ -33,3 +31,13 @@ doctrine:
         driver: "pdo_sqlite"
         path: "%kernel.cache_dir%/db.sql"
         charset: UTF8
+
+fos_rest:
+    exception: ~
+    view:
+        formats:
+            json: true
+        empty_content: 204
+    format_listener:
+        rules:
+            - { path: '^/shop-api', priorities: ['json'], fallback_format: json, prefer_extension: true }


### PR DESCRIPTION
This file is useless because `fos_rest.format_listener.rules` has to be defined only once. It is already covered in README file