### PR TITLE
[Sylius] Remove ShopBundle from tests dependencies

### DIFF
--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -13,14 +13,15 @@
 
 <container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
     <services>
+        <service id="sylius.shop_api_plugin.builder.image_view_builder" class="Sylius\ShopApiPlugin\Builder\ImageViewBuilder">
+            <argument type="service" id="liip_imagine.cache.manager" />
+        </service>
+
+        <!-- TODO: Should be removed when problem with autostarting session will be resolved -->
         <service id="sylius.listener.session_cart" class="Sylius\Bundle\CoreBundle\EventListener\SessionCartSubscriber">
             <argument type="service" id="sylius.context.cart" />
             <argument>_sylius.cart</argument>
             <argument type="service" id="security.firewall.map" />
-        </service>
-
-        <service id="sylius.shop_api_plugin.builder.image_view_builder" class="Sylius\ShopApiPlugin\Builder\ImageViewBuilder">
-            <argument type="service" id="liip_imagine.cache.manager" />
         </service>
     </services>
 </container>

--- a/tests/Application/app/AppKernel.php
+++ b/tests/Application/app/AppKernel.php
@@ -12,7 +12,6 @@ final class AppKernel extends Kernel
     {
         return array_merge(parent::registerBundles(), [
             new \Sylius\Bundle\AdminBundle\SyliusAdminBundle(),
-            new \Sylius\Bundle\ShopBundle\SyliusShopBundle(),
 
             new \FOS\OAuthServerBundle\FOSOAuthServerBundle(), // Required by SyliusApiBundle
             new \Sylius\Bundle\AdminApiBundle\SyliusAdminApiBundle(),

--- a/tests/Application/app/config/config.yml
+++ b/tests/Application/app/config/config.yml
@@ -5,7 +5,6 @@ parameters:
 imports:
     - { resource: "@SyliusCoreBundle/Resources/config/app/config.yml" }
     - { resource: "@SyliusAdminBundle/Resources/config/app/config.yml" }
-    - { resource: "@SyliusShopBundle/Resources/config/app/config.yml" }
     - { resource: "@SyliusAdminApiBundle/Resources/config/app/config.yml" }
 
     - { resource: "@ShopApiPlugin/Resources/config/app/config.yml" }
@@ -43,3 +42,7 @@ fos_rest:
     format_listener:
         rules:
             - { path: '^/shop-api', priorities: ['json'], fallback_format: json, prefer_extension: true }
+
+liip_imagine:
+    filter_sets:
+        sylius_shop_product_original: ~

--- a/tests/Application/app/config/routing.yml
+++ b/tests/Application/app/config/routing.yml
@@ -1,5 +1,13 @@
-sylius:
-    resource: "../../../../vendor/sylius/sylius/app/config/routing.yml"
+sylius_admin:
+    resource: "@SyliusAdminBundle/Resources/config/routing.yml"
+    prefix: /admin
+
+sylius_admin_api:
+    resource: "@SyliusAdminApiBundle/Resources/config/routing.yml"
+    prefix: /api
+
+_liip_imagine:
+    resource: "@LiipImagineBundle/Resources/config/routing.xml"
 
 # Put your own routes here
 

--- a/tests/Responses/Expected/cart/filled_cart_with_product_variant_summary_response.json
+++ b/tests/Responses/Expected/cart/filled_cart_with_product_variant_summary_response.json
@@ -16,15 +16,15 @@
                 "images": [
                     {
                         "code": "thumbnail",
-                        "url": "http:\/\/localhost\/en_US\/media\/cache\/resolve\/sylius_small\/uo\/tshirt.jpg"
+                        "url": "http:\/\/localhost\/media\/cache\/resolve\/sylius_small\/uo\/tshirt.jpg"
                     },
                     {
                         "code": "thumbnail",
-                        "url": "http:\/\/localhost\/en_US\/media\/cache\/resolve\/sylius_small\/uo\/samll-tshirt.jpg"
+                        "url": "http:\/\/localhost\/media\/cache\/resolve\/sylius_small\/uo\/samll-tshirt.jpg"
                     },
                     {
                         "code": "thumbnail",
-                        "url": "http:\/\/localhost\/en_US\/media\/cache\/resolve\/sylius_small\/uo\/large-tshirt.jpg"
+                        "url": "http:\/\/localhost\/media\/cache\/resolve\/sylius_small\/uo\/large-tshirt.jpg"
                     }
                 ]
             },
@@ -34,7 +34,7 @@
                 "images": [
                     {
                         "code": "thumbnail",
-                        "url": "http:\/\/localhost\/en_US\/media\/cache\/resolve\/sylius_small\/uo\/samll-tshirt.jpg"
+                        "url": "http:\/\/localhost\/media\/cache\/resolve\/sylius_small\/uo\/samll-tshirt.jpg"
                     }
                 ],
                 "options": []

--- a/tests/Responses/Expected/cart/filled_cart_with_simple_product_summary_response.json
+++ b/tests/Responses/Expected/cart/filled_cart_with_simple_product_summary_response.json
@@ -16,7 +16,7 @@
                 "images": [
                     {
                         "code": "thumbnail",
-                        "url": "http:\/\/localhost\/en_US\/media\/cache\/resolve\/sylius_small\/uo\/mug.jpg"
+                        "url": "http:\/\/localhost\/media\/cache\/resolve\/sylius_small\/uo\/mug.jpg"
                     }
                 ]
             }

--- a/tests/Responses/Expected/cart/german_filled_cart_with_simple_product_summary_response.json
+++ b/tests/Responses/Expected/cart/german_filled_cart_with_simple_product_summary_response.json
@@ -16,7 +16,7 @@
                 "images": [
                     {
                         "code": "thumbnail",
-                        "url": "http:\/\/localhost\/en_US\/media\/cache\/resolve\/sylius_small\/uo\/mug.jpg"
+                        "url": "http:\/\/localhost\/media\/cache\/resolve\/sylius_small\/uo\/mug.jpg"
                     }
                 ]
             }

--- a/tests/Responses/Expected/product/german_simple_product_details_page.json
+++ b/tests/Responses/Expected/product/german_simple_product_details_page.json
@@ -13,7 +13,7 @@
             "images": [
                 {
                     "code": "thumbnail",
-                    "url": "http:\/\/localhost\/en_US\/media\/cache\/resolve\/sylius_small\/uo\/mug.jpg"
+                    "url": "http:\/\/localhost\/media\/cache\/resolve\/sylius_small\/uo\/mug.jpg"
                 }
             ],
             "applied_promotions": []
@@ -24,7 +24,7 @@
     "images": [
         {
             "code": "thumbnail",
-            "url": "http:\/\/localhost\/en_US\/media\/cache\/resolve\/sylius_small\/uo\/mug.jpg"
+            "url": "http:\/\/localhost\/media\/cache\/resolve\/sylius_small\/uo\/mug.jpg"
         }
     ],
     "_links": {

--- a/tests/Responses/Expected/product/limited_product_list_page.json
+++ b/tests/Responses/Expected/product/limited_product_list_page.json
@@ -25,7 +25,7 @@
                     "images": [
                         {
                             "code": "thumbnail",
-                            "url": "http:\/\/localhost\/en_US\/media\/cache\/resolve\/sylius_small\/uo\/samll-tshirt.jpg"
+                            "url": "http:\/\/localhost\/media\/cache\/resolve\/sylius_small\/uo\/samll-tshirt.jpg"
                         }
                     ],
                     "applied_promotions": []
@@ -39,7 +39,7 @@
                     "images": [
                         {
                             "code": "thumbnail",
-                            "url": "http:\/\/localhost\/en_US\/media\/cache\/resolve\/sylius_small\/uo\/large-tshirt.jpg"
+                            "url": "http:\/\/localhost\/media\/cache\/resolve\/sylius_small\/uo\/large-tshirt.jpg"
                         }
                     ],
                     "applied_promotions": []
@@ -50,15 +50,15 @@
             "images": [
                 {
                     "code": "thumbnail",
-                    "url": "http:\/\/localhost\/en_US\/media\/cache\/resolve\/sylius_small\/uo\/tshirt.jpg"
+                    "url": "http:\/\/localhost\/media\/cache\/resolve\/sylius_small\/uo\/tshirt.jpg"
                 },
                 {
                     "code": "thumbnail",
-                    "url": "http:\/\/localhost\/en_US\/media\/cache\/resolve\/sylius_small\/uo\/samll-tshirt.jpg"
+                    "url": "http:\/\/localhost\/media\/cache\/resolve\/sylius_small\/uo\/samll-tshirt.jpg"
                 },
                 {
                     "code": "thumbnail",
-                    "url": "http:\/\/localhost\/en_US\/media\/cache\/resolve\/sylius_small\/uo\/large-tshirt.jpg"
+                    "url": "http:\/\/localhost\/media\/cache\/resolve\/sylius_small\/uo\/large-tshirt.jpg"
                 }
             ],
             "_links": {

--- a/tests/Responses/Expected/product/product_list_page.json
+++ b/tests/Responses/Expected/product/product_list_page.json
@@ -25,7 +25,7 @@
                     "images": [
                         {
                             "code": "thumbnail",
-                            "url": "http:\/\/localhost\/en_US\/media\/cache\/resolve\/sylius_small\/uo\/mug.jpg"
+                            "url": "http:\/\/localhost\/media\/cache\/resolve\/sylius_small\/uo\/mug.jpg"
                         }
                     ],
                     "applied_promotions": []
@@ -36,7 +36,7 @@
             "images": [
                 {
                     "code": "thumbnail",
-                    "url": "http:\/\/localhost\/en_US\/media\/cache\/resolve\/sylius_small\/uo\/mug.jpg"
+                    "url": "http:\/\/localhost\/media\/cache\/resolve\/sylius_small\/uo\/mug.jpg"
                 }
             ],
             "_links": {
@@ -60,7 +60,7 @@
                     "images": [
                         {
                             "code": "thumbnail",
-                            "url": "http:\/\/localhost\/en_US\/media\/cache\/resolve\/sylius_small\/uo\/samll-tshirt.jpg"
+                            "url": "http:\/\/localhost\/media\/cache\/resolve\/sylius_small\/uo\/samll-tshirt.jpg"
                         }
                     ],
                     "applied_promotions": []
@@ -74,7 +74,7 @@
                     "images": [
                         {
                             "code": "thumbnail",
-                            "url": "http:\/\/localhost\/en_US\/media\/cache\/resolve\/sylius_small\/uo\/large-tshirt.jpg"
+                            "url": "http:\/\/localhost\/media\/cache\/resolve\/sylius_small\/uo\/large-tshirt.jpg"
                         }
                     ],
                     "applied_promotions": []
@@ -85,15 +85,15 @@
             "images": [
                 {
                     "code": "thumbnail",
-                    "url": "http:\/\/localhost\/en_US\/media\/cache\/resolve\/sylius_small\/uo\/tshirt.jpg"
+                    "url": "http:\/\/localhost\/media\/cache\/resolve\/sylius_small\/uo\/tshirt.jpg"
                 },
                 {
                     "code": "thumbnail",
-                    "url": "http:\/\/localhost\/en_US\/media\/cache\/resolve\/sylius_small\/uo\/samll-tshirt.jpg"
+                    "url": "http:\/\/localhost\/media\/cache\/resolve\/sylius_small\/uo\/samll-tshirt.jpg"
                 },
                 {
                     "code": "thumbnail",
-                    "url": "http:\/\/localhost\/en_US\/media\/cache\/resolve\/sylius_small\/uo\/large-tshirt.jpg"
+                    "url": "http:\/\/localhost\/media\/cache\/resolve\/sylius_small\/uo\/large-tshirt.jpg"
                 }
             ],
             "_links": {

--- a/tests/Responses/Expected/product/product_with_variant_details_page.json
+++ b/tests/Responses/Expected/product/product_with_variant_details_page.json
@@ -13,7 +13,7 @@
             "images": [
                 {
                     "code": "thumbnail",
-                    "url": "http:\/\/localhost\/en_US\/media\/cache\/resolve\/sylius_small\/uo\/samll-tshirt.jpg"
+                    "url": "http:\/\/localhost\/media\/cache\/resolve\/sylius_small\/uo\/samll-tshirt.jpg"
                 }
             ],
             "applied_promotions": []
@@ -27,7 +27,7 @@
             "images": [
                 {
                     "code": "thumbnail",
-                    "url": "http:\/\/localhost\/en_US\/media\/cache\/resolve\/sylius_small\/uo\/large-tshirt.jpg"
+                    "url": "http:\/\/localhost\/media\/cache\/resolve\/sylius_small\/uo\/large-tshirt.jpg"
                 }
             ],
             "applied_promotions": []
@@ -38,15 +38,15 @@
     "images": [
         {
             "code": "thumbnail",
-            "url": "http:\/\/localhost\/en_US\/media\/cache\/resolve\/sylius_small\/uo\/tshirt.jpg"
+            "url": "http:\/\/localhost\/media\/cache\/resolve\/sylius_small\/uo\/tshirt.jpg"
         },
         {
             "code": "thumbnail",
-            "url": "http:\/\/localhost\/en_US\/media\/cache\/resolve\/sylius_small\/uo\/samll-tshirt.jpg"
+            "url": "http:\/\/localhost\/media\/cache\/resolve\/sylius_small\/uo\/samll-tshirt.jpg"
         },
         {
             "code": "thumbnail",
-            "url": "http:\/\/localhost\/en_US\/media\/cache\/resolve\/sylius_small\/uo\/large-tshirt.jpg"
+            "url": "http:\/\/localhost\/media\/cache\/resolve\/sylius_small\/uo\/large-tshirt.jpg"
         }
     ],
     "_links": {

--- a/tests/Responses/Expected/product/simple_product_details_page.json
+++ b/tests/Responses/Expected/product/simple_product_details_page.json
@@ -13,7 +13,7 @@
             "images": [
                 {
                     "code": "thumbnail",
-                    "url": "http:\/\/localhost\/en_US\/media\/cache\/resolve\/sylius_small\/uo\/mug.jpg"
+                    "url": "http:\/\/localhost\/media\/cache\/resolve\/sylius_small\/uo\/mug.jpg"
                 }
             ],
             "applied_promotions": []
@@ -24,7 +24,7 @@
     "images": [
         {
             "code": "thumbnail",
-            "url": "http:\/\/localhost\/en_US\/media\/cache\/resolve\/sylius_small\/uo\/mug.jpg"
+            "url": "http:\/\/localhost\/media\/cache\/resolve\/sylius_small\/uo\/mug.jpg"
         }
     ],
     "_links": {

--- a/tests/Responses/Expected/taxon/all_taxons_response.json
+++ b/tests/Responses/Expected/taxon/all_taxons_response.json
@@ -53,7 +53,7 @@
                 "images": [
                     {
                         "code": "thumbnail",
-                        "url": "http:\/\/localhost\/en_US\/media\/cache\/resolve\/sylius_small\/uo\/t-shirt.jpg"
+                        "url": "http:\/\/localhost\/media\/cache\/resolve\/sylius_small\/uo\/t-shirt.jpg"
                     }
                 ]
             }

--- a/tests/Responses/Expected/taxon/german_all_taxons_response.json
+++ b/tests/Responses/Expected/taxon/german_all_taxons_response.json
@@ -53,7 +53,7 @@
                 "images": [
                     {
                         "code": "thumbnail",
-                        "url": "http:\/\/localhost\/en_US\/media\/cache\/resolve\/sylius_small\/uo\/t-shirt.jpg"
+                        "url": "http:\/\/localhost\/media\/cache\/resolve\/sylius_small\/uo\/t-shirt.jpg"
                     }
                 ]
             }

--- a/tests/Responses/Expected/taxon/german_one_of_taxons_response.json
+++ b/tests/Responses/Expected/taxon/german_one_of_taxons_response.json
@@ -27,7 +27,7 @@
     "images": [
         {
             "code": "thumbnail",
-            "url": "http:\/\/localhost\/en_US\/media\/cache\/resolve\/sylius_small\/uo\/t-shirt.jpg"
+            "url": "http:\/\/localhost\/media\/cache\/resolve\/sylius_small\/uo\/t-shirt.jpg"
         }
     ]
 }

--- a/tests/Responses/Expected/taxon/one_of_taxons_response.json
+++ b/tests/Responses/Expected/taxon/one_of_taxons_response.json
@@ -27,7 +27,7 @@
     "images": [
         {
             "code": "thumbnail",
-            "url": "http:\/\/localhost\/en_US\/media\/cache\/resolve\/sylius_small\/uo\/t-shirt.jpg"
+            "url": "http:\/\/localhost\/media\/cache\/resolve\/sylius_small\/uo\/t-shirt.jpg"
         }
     ]
 }


### PR DESCRIPTION
ShopBundle didn't work either because I was forced to remove one of its dependencies previously. Bringing back ShopBundle support can be defined as an issue, but I think it would be better to have two separate bundles working rather than only one.