### PR TITLE
[Checkout] Show and choose available shipping methods

### DIFF
--- a/spec/Command/AddressOrderSpec.php
+++ b/spec/Command/AddressOrderSpec.php
@@ -12,7 +12,7 @@ final class AddressOrderSpec extends ObjectBehavior
 {
     function let()
     {
-        $this->beConstructedThrough('create', [
+        $this->beConstructedWith(
             'ORDERTOKEN',
             Address::createFromArray([
                 'firstName' => 'Sherlock',
@@ -31,8 +31,8 @@ final class AddressOrderSpec extends ObjectBehavior
                 'countryCode' => 'GB',
                 'postcode' => 'NWB',
                 'provinceName' => 'Greater London',
-            ]),
-        ]);
+            ])
+        );
     }
 
     function it_is_initializable()

--- a/spec/Command/ChooseShippingMethodSpec.php
+++ b/spec/Command/ChooseShippingMethodSpec.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace spec\Sylius\ShopApiPlugin\Command;
+
+use Sylius\ShopApiPlugin\Command\ChooseShippingMethod;
+use PhpSpec\ObjectBehavior;
+
+final class ChooseShippingMethodSpec extends ObjectBehavior
+{
+    function let()
+    {
+        $this->beConstructedWith('ORDERTOKEN', 1, 'DHL_SHIPPING_METHOD');
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType(ChooseShippingMethod::class);
+    }
+
+    function it_has_order_token()
+    {
+        $this->orderToken()->shouldReturn('ORDERTOKEN');
+    }
+
+    function it_has_identifier_of_shipping()
+    {
+        $this->shippingIdentifier()->shouldReturn(1);
+    }
+
+    function it_has_shipping_method_defined()
+    {
+        $this->shippingMethod()->shouldReturn('DHL_SHIPPING_METHOD');
+    }
+}

--- a/spec/Command/ChooseShippingMethodSpec.php
+++ b/spec/Command/ChooseShippingMethodSpec.php
@@ -24,7 +24,7 @@ final class ChooseShippingMethodSpec extends ObjectBehavior
 
     function it_has_identifier_of_shipping()
     {
-        $this->shippingIdentifier()->shouldReturn(1);
+        $this->shipmentIdentifier()->shouldReturn(1);
     }
 
     function it_has_shipping_method_defined()

--- a/spec/Command/PickupCartSpec.php
+++ b/spec/Command/PickupCartSpec.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace spec\Sylius\ShopApiPlugin\Command;
+
+use Sylius\ShopApiPlugin\Command\PickupCart;
+use PhpSpec\ObjectBehavior;
+
+final class PickupCartSpec extends ObjectBehavior
+{
+    function let()
+    {
+        $this->beConstructedWith('ORDERTOKEN', 'CHANNEL_CODE');
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType(PickupCart::class);
+    }
+
+    function it_has_order_token()
+    {
+        $this->token()->shouldReturn('ORDERTOKEN');
+    }
+
+    function it_has_channel_code()
+    {
+        $this->channelCode()->shouldReturn('CHANNEL_CODE');
+    }
+}

--- a/spec/Command/PutSimpleItemToCartSpec.php
+++ b/spec/Command/PutSimpleItemToCartSpec.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace spec\Sylius\ShopApiPlugin\Command;
+
+use Sylius\ShopApiPlugin\Command\PutSimpleItemToCart;
+use PhpSpec\ObjectBehavior;
+
+final class PutSimpleItemToCartSpec extends ObjectBehavior
+{
+    function let()
+    {
+        $this->beConstructedWith('ORDERTOKEN', 'T_SHIRT_CODE', 5);
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType(PutSimpleItemToCart::class);
+    }
+
+    function it_has_order_token()
+    {
+        $this->token()->shouldReturn('ORDERTOKEN');
+    }
+
+    function it_has_product_code()
+    {
+        $this->product()->shouldReturn('T_SHIRT_CODE');
+    }
+
+    function it_has_quantity()
+    {
+        $this->quantity()->shouldReturn(5);
+    }
+}

--- a/spec/Handler/AddressOrderHandlerSpec.php
+++ b/spec/Handler/AddressOrderHandlerSpec.php
@@ -61,7 +61,7 @@ final class AddressOrderHandlerSpec extends ObjectBehavior
         $stateMachine->can('address')->willReturn(true);
         $stateMachine->apply('address')->shouldBeCalled();
 
-        $this->handle(AddressShipmentCommand::create(
+        $this->handle(new AddressShipmentCommand(
             'ORDERTOKEN',
             Address::createFromArray([
                 'firstName' => 'Sherlock',

--- a/spec/Handler/AddressOrderHandlerSpec.php
+++ b/spec/Handler/AddressOrderHandlerSpec.php
@@ -90,7 +90,7 @@ final class AddressOrderHandlerSpec extends ObjectBehavior
         $orderRepository->findOneBy(['tokenValue' => 'ORDERTOKEN'])->willReturn(null);
 
         $this->shouldThrow(\LogicException::class)->during('handle', [
-            AddressShipmentCommand::create(
+            new AddressShipmentCommand(
                 'ORDERTOKEN',
                 Address::createFromArray([
                     'firstName' => 'Sherlock',
@@ -126,7 +126,7 @@ final class AddressOrderHandlerSpec extends ObjectBehavior
         $stateMachine->can('address')->willReturn(false);
 
         $this->shouldThrow(\LogicException::class)->during('handle', [
-            AddressShipmentCommand::create(
+            new AddressShipmentCommand(
                 'ORDERTOKEN',
                 Address::createFromArray([
                     'firstName' => 'Sherlock',

--- a/spec/Handler/ChooseShippingMethodHandlerSpec.php
+++ b/spec/Handler/ChooseShippingMethodHandlerSpec.php
@@ -1,0 +1,178 @@
+<?php
+
+namespace spec\Sylius\ShopApiPlugin\Handler;
+
+use Prophecy\Argument;
+use SM\Factory\FactoryInterface;
+use SM\StateMachine\StateMachineInterface;
+use Sylius\Component\Core\Model\OrderInterface;
+use Sylius\Component\Core\Model\ShipmentInterface;
+use Sylius\Component\Core\Model\ShippingMethodInterface;
+use Sylius\Component\Core\OrderCheckoutTransitions;
+use Sylius\Component\Core\Repository\OrderRepositoryInterface;
+use Sylius\Component\Core\Repository\ShippingMethodRepositoryInterface;
+use Sylius\Component\Shipping\Checker\ShippingMethodEligibilityCheckerInterface;
+use Sylius\ShopApiPlugin\Command\ChooseShippingMethod;
+use Sylius\ShopApiPlugin\Handler\ChooseShippingMethodHandler;
+use PhpSpec\ObjectBehavior;
+
+final class ChooseShippingMethodHandlerSpec extends ObjectBehavior
+{
+    function let(
+        OrderRepositoryInterface $orderRepository,
+        ShippingMethodRepositoryInterface $shippingMethodRepository,
+        ShippingMethodEligibilityCheckerInterface $eligibilityChecker,
+        FactoryInterface $stateMachineFactory
+    ) {
+        $this->beConstructedWith($orderRepository, $shippingMethodRepository, $eligibilityChecker, $stateMachineFactory);
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType(ChooseShippingMethodHandler::class);
+    }
+
+    function it_assignes_choosen_shipping_method_to_specified_shipment(
+        OrderRepositoryInterface $orderRepository,
+        OrderInterface $order,
+        ShippingMethodRepositoryInterface $shippingMethodRepository,
+        ShippingMethodInterface $shippingMethod,
+        ShipmentInterface $shipment,
+        ShippingMethodEligibilityCheckerInterface $eligibilityChecker,
+        FactoryInterface $stateMachineFactory,
+        StateMachineInterface $stateMachine
+    ) {
+        $orderRepository->findOneBy(['tokenValue' => 'ORDERTOKEN'])->willReturn($order);
+        $order->getShipments()->willReturn([$shipment]);
+        $shippingMethodRepository->findOneBy(['code' => 'DHL_SHIPPING_METHOD'])->willReturn($shippingMethod);
+
+        $eligibilityChecker->isEligible($shipment, $shippingMethod)->willReturn(true);
+
+        $stateMachineFactory->get($order, OrderCheckoutTransitions::GRAPH)->willReturn($stateMachine);
+        $stateMachine->can('select_shipping')->willReturn(true);
+
+        $shipment->setMethod($shippingMethod)->shouldBeCalled();
+        $stateMachine->apply('select_shipping')->shouldBeCalled();
+
+        $this->handle(new ChooseShippingMethod('ORDERTOKEN',0, 'DHL_SHIPPING_METHOD'));
+    }
+
+    function it_throws_logical_exception_if_shipping_method_is_not_eligible(
+        OrderRepositoryInterface $orderRepository,
+        OrderInterface $order,
+        ShippingMethodRepositoryInterface $shippingMethodRepository,
+        ShippingMethodInterface $shippingMethod,
+        ShipmentInterface $shipment,
+        ShippingMethodEligibilityCheckerInterface $eligibilityChecker,
+        FactoryInterface $stateMachineFactory,
+        StateMachineInterface $stateMachine
+    ) {
+        $orderRepository->findOneBy(['tokenValue' => 'ORDERTOKEN'])->willReturn($order);
+        $order->getShipments()->willReturn([$shipment]);
+        $shippingMethodRepository->findOneBy(['code' => 'DHL_SHIPPING_METHOD'])->willReturn($shippingMethod);
+
+        $eligibilityChecker->isEligible($shipment, $shippingMethod)->willReturn(false);
+        $stateMachineFactory->get($order, OrderCheckoutTransitions::GRAPH)->willReturn($stateMachine);
+        $stateMachine->can('select_shipping')->willReturn(true);
+
+        $shipment->setMethod(Argument::type(ShippingMethodInterface::class))->shouldNotBeCalled();
+        $stateMachine->apply('select_shipping')->shouldNotBeCalled();
+
+        $this
+            ->shouldThrow(\LogicException::class)
+            ->during('handle', [
+                new ChooseShippingMethod('ORDERTOKEN',0, 'DHL_SHIPPING_METHOD'),
+            ])
+        ;
+    }
+
+    function it_throws_logical_exception_if_order_with_given_token_has_not_been_found(
+        OrderRepositoryInterface $orderRepository,
+        ShipmentInterface $shipment
+    ) {
+        $orderRepository->findOneBy(['tokenValue' => 'ORDERTOKEN'])->willReturn(null);
+
+        $shipment->setMethod(Argument::type(ShippingMethodInterface::class))->shouldNotBeCalled();
+
+        $this
+            ->shouldThrow(\LogicException::class)
+            ->during('handle', [
+                new ChooseShippingMethod('ORDERTOKEN',0, 'DHL_SHIPPING_METHOD'),
+            ])
+        ;
+    }
+
+    function it_throws_logical_exception_order_cannot_have_shipping_selected(
+        OrderRepositoryInterface $orderRepository,
+        OrderInterface $order,
+        ShippingMethodRepositoryInterface $shippingMethodRepository,
+        ShipmentInterface $shipment,
+        FactoryInterface $stateMachineFactory,
+        StateMachineInterface $stateMachine
+    ) {
+        $orderRepository->findOneBy(['tokenValue' => 'ORDERTOKEN'])->willReturn($order);
+        $shippingMethodRepository->findOneBy(['code' => 'DHL_SHIPPING_METHOD'])->willReturn(null);
+        $stateMachineFactory->get($order, OrderCheckoutTransitions::GRAPH)->willReturn($stateMachine);
+        $stateMachine->can('select_shipping')->willReturn(false);
+
+        $shipment->setMethod(Argument::type(ShippingMethodInterface::class))->shouldNotBeCalled();
+        $stateMachine->apply('select_shipping')->shouldNotBeCalled();
+
+        $this
+            ->shouldThrow(\LogicException::class)
+            ->during('handle', [
+                new ChooseShippingMethod('ORDERTOKEN',0, 'DHL_SHIPPING_METHOD'),
+            ])
+        ;
+    }
+
+    function it_throws_logical_exception_if_shipping_method_with_given_code_has_not_been_found(
+        OrderRepositoryInterface $orderRepository,
+        OrderInterface $order,
+        ShippingMethodRepositoryInterface $shippingMethodRepository,
+        ShipmentInterface $shipment,
+        FactoryInterface $stateMachineFactory,
+        StateMachineInterface $stateMachine
+    ) {
+        $orderRepository->findOneBy(['tokenValue' => 'ORDERTOKEN'])->willReturn($order);
+        $shippingMethodRepository->findOneBy(['code' => 'DHL_SHIPPING_METHOD'])->willReturn(null);
+        $stateMachineFactory->get($order, OrderCheckoutTransitions::GRAPH)->willReturn($stateMachine);
+        $stateMachine->can('select_shipping')->willReturn(true);
+
+        $shipment->setMethod(Argument::type(ShippingMethodInterface::class))->shouldNotBeCalled();
+        $stateMachine->apply('select_shipping')->shouldNotBeCalled();
+
+        $this
+            ->shouldThrow(\LogicException::class)
+            ->during('handle', [
+                new ChooseShippingMethod('ORDERTOKEN',0, 'DHL_SHIPPING_METHOD'),
+            ])
+        ;
+    }
+
+    function it_throws_logical_exception_if_ordered_shipment_has_not_been_found(
+        OrderRepositoryInterface $orderRepository,
+        OrderInterface $order,
+        ShippingMethodRepositoryInterface $shippingMethodRepository,
+        ShippingMethodInterface $shippingMethod,
+        ShipmentInterface $shipment,
+        FactoryInterface $stateMachineFactory,
+        StateMachineInterface $stateMachine
+    ) {
+        $orderRepository->findOneBy(['tokenValue' => 'ORDERTOKEN'])->willReturn($order);
+        $shippingMethodRepository->findOneBy(['code' => 'DHL_SHIPPING_METHOD'])->willReturn($shippingMethod);
+        $order->getShipments()->willReturn([]);
+        $stateMachineFactory->get($order, OrderCheckoutTransitions::GRAPH)->willReturn($stateMachine);
+        $stateMachine->can('select_shipping')->willReturn(true);
+
+        $shipment->setMethod(Argument::type(ShippingMethodInterface::class))->shouldNotBeCalled();
+        $stateMachine->apply('select_shipping')->shouldNotBeCalled();
+
+        $this
+            ->shouldThrow(\LogicException::class)
+            ->during('handle', [
+                new ChooseShippingMethod('ORDERTOKEN',0, 'DHL_SHIPPING_METHOD'),
+            ])
+        ;
+    }
+}

--- a/spec/Handler/ChooseShippingMethodHandlerSpec.php
+++ b/spec/Handler/ChooseShippingMethodHandlerSpec.php
@@ -54,10 +54,10 @@ final class ChooseShippingMethodHandlerSpec extends ObjectBehavior
         $shipment->setMethod($shippingMethod)->shouldBeCalled();
         $stateMachine->apply('select_shipping')->shouldBeCalled();
 
-        $this->handle(new ChooseShippingMethod('ORDERTOKEN',0, 'DHL_SHIPPING_METHOD'));
+        $this->handle(new ChooseShippingMethod('ORDERTOKEN', 0, 'DHL_SHIPPING_METHOD'));
     }
 
-    function it_throws_logical_exception_if_shipping_method_is_not_eligible(
+    function it_throws_an_exception_if_shipping_method_is_not_eligible(
         OrderRepositoryInterface $orderRepository,
         OrderInterface $order,
         ShippingMethodRepositoryInterface $shippingMethodRepository,
@@ -79,14 +79,14 @@ final class ChooseShippingMethodHandlerSpec extends ObjectBehavior
         $stateMachine->apply('select_shipping')->shouldNotBeCalled();
 
         $this
-            ->shouldThrow(\LogicException::class)
+            ->shouldThrow(\InvalidArgumentException::class)
             ->during('handle', [
-                new ChooseShippingMethod('ORDERTOKEN',0, 'DHL_SHIPPING_METHOD'),
+                new ChooseShippingMethod('ORDERTOKEN', 0, 'DHL_SHIPPING_METHOD'),
             ])
         ;
     }
 
-    function it_throws_logical_exception_if_order_with_given_token_has_not_been_found(
+    function it_throws_an_exception_if_order_with_given_token_has_not_been_found(
         OrderRepositoryInterface $orderRepository,
         ShipmentInterface $shipment
     ) {
@@ -95,14 +95,14 @@ final class ChooseShippingMethodHandlerSpec extends ObjectBehavior
         $shipment->setMethod(Argument::type(ShippingMethodInterface::class))->shouldNotBeCalled();
 
         $this
-            ->shouldThrow(\LogicException::class)
+            ->shouldThrow(\InvalidArgumentException::class)
             ->during('handle', [
-                new ChooseShippingMethod('ORDERTOKEN',0, 'DHL_SHIPPING_METHOD'),
+                new ChooseShippingMethod('ORDERTOKEN', 0, 'DHL_SHIPPING_METHOD'),
             ])
         ;
     }
 
-    function it_throws_logical_exception_order_cannot_have_shipping_selected(
+    function it_throws_an_exception_if_order_cannot_have_shipping_selected(
         OrderRepositoryInterface $orderRepository,
         OrderInterface $order,
         ShippingMethodRepositoryInterface $shippingMethodRepository,
@@ -119,14 +119,14 @@ final class ChooseShippingMethodHandlerSpec extends ObjectBehavior
         $stateMachine->apply('select_shipping')->shouldNotBeCalled();
 
         $this
-            ->shouldThrow(\LogicException::class)
+            ->shouldThrow(\InvalidArgumentException::class)
             ->during('handle', [
-                new ChooseShippingMethod('ORDERTOKEN',0, 'DHL_SHIPPING_METHOD'),
+                new ChooseShippingMethod('ORDERTOKEN', 0, 'DHL_SHIPPING_METHOD'),
             ])
         ;
     }
 
-    function it_throws_logical_exception_if_shipping_method_with_given_code_has_not_been_found(
+    function it_throws_an_exception_if_shipping_method_with_given_code_has_not_been_found(
         OrderRepositoryInterface $orderRepository,
         OrderInterface $order,
         ShippingMethodRepositoryInterface $shippingMethodRepository,
@@ -143,14 +143,14 @@ final class ChooseShippingMethodHandlerSpec extends ObjectBehavior
         $stateMachine->apply('select_shipping')->shouldNotBeCalled();
 
         $this
-            ->shouldThrow(\LogicException::class)
+            ->shouldThrow(\InvalidArgumentException::class)
             ->during('handle', [
-                new ChooseShippingMethod('ORDERTOKEN',0, 'DHL_SHIPPING_METHOD'),
+                new ChooseShippingMethod('ORDERTOKEN', 0, 'DHL_SHIPPING_METHOD'),
             ])
         ;
     }
 
-    function it_throws_logical_exception_if_ordered_shipment_has_not_been_found(
+    function it_throws_an_exception_if_ordered_shipment_has_not_been_found(
         OrderRepositoryInterface $orderRepository,
         OrderInterface $order,
         ShippingMethodRepositoryInterface $shippingMethodRepository,
@@ -169,9 +169,9 @@ final class ChooseShippingMethodHandlerSpec extends ObjectBehavior
         $stateMachine->apply('select_shipping')->shouldNotBeCalled();
 
         $this
-            ->shouldThrow(\LogicException::class)
+            ->shouldThrow(\InvalidArgumentException::class)
             ->during('handle', [
-                new ChooseShippingMethod('ORDERTOKEN',0, 'DHL_SHIPPING_METHOD'),
+                new ChooseShippingMethod('ORDERTOKEN', 0, 'DHL_SHIPPING_METHOD'),
             ])
         ;
     }

--- a/spec/Handler/PickupCartHandlerSpec.php
+++ b/spec/Handler/PickupCartHandlerSpec.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace spec\Sylius\ShopApiPlugin\Handler;
+
+use Sylius\Component\Channel\Repository\ChannelRepositoryInterface;
+use Sylius\Component\Core\Model\ChannelInterface;
+use Sylius\Component\Core\Model\OrderInterface;
+use Sylius\Component\Core\Repository\OrderRepositoryInterface;
+use Sylius\Component\Currency\Model\CurrencyInterface;
+use Sylius\Component\Locale\Model\LocaleInterface;
+use Sylius\Component\Resource\Factory\FactoryInterface;
+use Sylius\ShopApiPlugin\Command\PickupCart;
+use Sylius\ShopApiPlugin\Handler\PickupCartHandler;
+use PhpSpec\ObjectBehavior;
+
+final class PickupCartHandlerSpec extends ObjectBehavior
+{
+    function let(FactoryInterface $cartFactory, OrderRepositoryInterface $cartRepository, ChannelRepositoryInterface $channelRepository)
+    {
+        $this->beConstructedWith($cartFactory, $cartRepository, $channelRepository);
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType(PickupCartHandler::class);
+    }
+
+    function it_handles_cart_pickup(
+        ChannelInterface $channel,
+        CurrencyInterface  $currency,
+        ChannelRepositoryInterface $channelRepository,
+        FactoryInterface $cartFactory,
+        LocaleInterface $locale,
+        OrderInterface $cart,
+        OrderRepositoryInterface $cartRepository
+    ) {
+        $channelRepository->findOneByCode('CHANNEL_CODE')->willReturn($channel);
+        $channel->getBaseCurrency()->willReturn($currency);
+        $channel->getDefaultLocale()->willReturn($locale);
+        $currency->getCode()->willReturn('EUR');
+        $locale->getCode()->willReturn('de_DE');
+
+        $cartFactory->createNew()->willReturn($cart);
+
+        $cart->setChannel($channel)->shouldBeCalled();
+        $cart->setTokenValue('ORDERTOKEN')->shouldBeCalled();
+        $cart->setCurrencyCode('EUR')->shouldBeCalled();
+        $cart->setLocaleCode('de_DE')->shouldBeCalled();
+
+        $cartRepository->add($cart)->shouldBeCalled();
+
+        $this->handle(new PickupCart('ORDERTOKEN', 'CHANNEL_CODE'));
+    }
+}

--- a/spec/Handler/PutSimpleItemToCartHandlerSpec.php
+++ b/spec/Handler/PutSimpleItemToCartHandlerSpec.php
@@ -62,4 +62,26 @@ final class PutSimpleItemToCartHandlerSpec extends ObjectBehavior
 
         $this->handle(new PutSimpleItemToCart('ORDERTOKEN', 'T_SHIRT_CODE', 5));
     }
+
+    function it_throws_an_exception_if_cart_has_not_been_found(OrderRepositoryInterface $cartRepository)
+    {
+        $cartRepository->findOneBy(['tokenValue' => 'ORDERTOKEN'])->willReturn(null);
+
+        $this->shouldThrow(\InvalidArgumentException::class)->during('handle', [
+            new PutSimpleItemToCart('ORDERTOKEN', 'T_SHIRT_CODE', 5),
+        ]);
+    }
+
+    function it_throws_an_exception_if_product_has_not_been_found(
+        OrderInterface $cart,
+        OrderRepositoryInterface $cartRepository,
+        ProductRepositoryInterface $productRepository
+    ) {
+        $cartRepository->findOneBy(['tokenValue' => 'ORDERTOKEN'])->willReturn($cart);
+        $productRepository->findOneBy(['code' => 'T_SHIRT_CODE'])->willReturn(null);
+
+        $this->shouldThrow(\InvalidArgumentException::class)->during('handle', [
+            new PutSimpleItemToCart('ORDERTOKEN', 'T_SHIRT_CODE', 5),
+        ]);
+    }
 }

--- a/spec/Handler/PutSimpleItemToCartHandlerSpec.php
+++ b/spec/Handler/PutSimpleItemToCartHandlerSpec.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace spec\Sylius\ShopApiPlugin\Handler;
+
+use Sylius\Component\Core\Factory\CartItemFactoryInterface;
+use Sylius\Component\Core\Model\OrderInterface;
+use Sylius\Component\Core\Model\OrderItemInterface;
+use Sylius\Component\Core\Model\ProductInterface;
+use Sylius\Component\Core\Model\ProductVariantInterface;
+use Sylius\Component\Core\Repository\OrderRepositoryInterface;
+use Sylius\Component\Core\Repository\ProductRepositoryInterface;
+use Sylius\Component\Order\Modifier\OrderItemQuantityModifierInterface;
+use Sylius\Component\Order\Processor\OrderProcessorInterface;
+use Sylius\ShopApiPlugin\Command\PutSimpleItemToCart;
+use Sylius\ShopApiPlugin\Handler\PutSimpleItemToCartHandler;
+use PhpSpec\ObjectBehavior;
+
+final class PutSimpleItemToCartHandlerSpec extends ObjectBehavior
+{
+    function let(
+        OrderRepositoryInterface $cartRepository,
+        ProductRepositoryInterface $productRepository,
+        CartItemFactoryInterface $cartItemFactory,
+        OrderItemQuantityModifierInterface $orderItemModifier,
+        OrderProcessorInterface $orderProcessor
+    ) {
+        $this->beConstructedWith($cartRepository, $productRepository, $cartItemFactory, $orderItemModifier, $orderProcessor);
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType(PutSimpleItemToCartHandler::class);
+    }
+
+    function it_handles_putting_new_item_to_cart(
+        OrderItemInterface $cartItem,
+        OrderInterface $cart,
+        CartItemFactoryInterface $cartItemFactory,
+        OrderItemQuantityModifierInterface $orderItemModifier,
+        OrderProcessorInterface $orderProcessor,
+        OrderRepositoryInterface $cartRepository,
+        ProductInterface $product,
+        ProductRepositoryInterface $productRepository,
+        ProductVariantInterface $productVariant
+    ) {
+        $productRepository->findOneBy(['code' => 'T_SHIRT_CODE'])->willReturn($product);
+        $product->getVariants()->willReturn([$productVariant]);
+        $product->isSimple()->willReturn(true);
+
+        $cartRepository->findOneBy(['tokenValue' => 'ORDERTOKEN'])->willReturn($cart);
+        $cartItemFactory->createForCart($cart)->willReturn($cartItem);
+
+        $cartItem->setVariant($productVariant)->shouldBeCalled();
+        $orderItemModifier->modify($cartItem, 5)->shouldBeCalled();
+
+        $orderProcessor->process($cart)->shouldBeCalled();
+
+        $this->handle(new PutSimpleItemToCart('ORDERTOKEN', 'T_SHIRT_CODE', 5));
+    }
+}

--- a/spec/Handler/PutSimpleItemToCartHandlerSpec.php
+++ b/spec/Handler/PutSimpleItemToCartHandlerSpec.php
@@ -2,6 +2,7 @@
 
 namespace spec\Sylius\ShopApiPlugin\Handler;
 
+use Doctrine\Common\Persistence\ObjectManager;
 use Sylius\Component\Core\Factory\CartItemFactoryInterface;
 use Sylius\Component\Core\Model\OrderInterface;
 use Sylius\Component\Core\Model\OrderItemInterface;
@@ -22,9 +23,10 @@ final class PutSimpleItemToCartHandlerSpec extends ObjectBehavior
         ProductRepositoryInterface $productRepository,
         CartItemFactoryInterface $cartItemFactory,
         OrderItemQuantityModifierInterface $orderItemModifier,
-        OrderProcessorInterface $orderProcessor
+        OrderProcessorInterface $orderProcessor,
+        ObjectManager $manager
     ) {
-        $this->beConstructedWith($cartRepository, $productRepository, $cartItemFactory, $orderItemModifier, $orderProcessor);
+        $this->beConstructedWith($cartRepository, $productRepository, $cartItemFactory, $orderItemModifier, $orderProcessor, $manager);
     }
 
     function it_is_initializable()
@@ -41,7 +43,8 @@ final class PutSimpleItemToCartHandlerSpec extends ObjectBehavior
         OrderRepositoryInterface $cartRepository,
         ProductInterface $product,
         ProductRepositoryInterface $productRepository,
-        ProductVariantInterface $productVariant
+        ProductVariantInterface $productVariant,
+        ObjectManager $manager
     ) {
         $productRepository->findOneBy(['code' => 'T_SHIRT_CODE'])->willReturn($product);
         $product->getVariants()->willReturn([$productVariant]);
@@ -54,6 +57,8 @@ final class PutSimpleItemToCartHandlerSpec extends ObjectBehavior
         $orderItemModifier->modify($cartItem, 5)->shouldBeCalled();
 
         $orderProcessor->process($cart)->shouldBeCalled();
+
+        $manager->persist($cart)->shouldBeCalled();
 
         $this->handle(new PutSimpleItemToCart('ORDERTOKEN', 'T_SHIRT_CODE', 5));
     }

--- a/src/Command/AddressOrder.php
+++ b/src/Command/AddressOrder.php
@@ -26,27 +26,11 @@ final class AddressOrder
      * @param Address $shippingAddress
      * @param Address $billingAddress
      */
-    private function __construct($orderId, Address $shippingAddress, Address $billingAddress)
+    public function __construct($orderId, Address $shippingAddress, Address $billingAddress)
     {
         $this->orderToken = $orderId;
         $this->address = $shippingAddress;
         $this->billingAddress = $billingAddress;
-    }
-
-    /**
-     * @param string $orderToken
-     * @param Address $shippingAddress
-     * @param Address $billingAddress
-     *
-     * @return AddressOrder
-     */
-    public static function create($orderToken, Address $shippingAddress, Address $billingAddress)
-    {
-        return new AddressOrder(
-            $orderToken,
-            $shippingAddress,
-            $billingAddress
-        );
     }
 
     /**

--- a/src/Command/ChooseShippingMethod.php
+++ b/src/Command/ChooseShippingMethod.php
@@ -7,7 +7,7 @@ final class ChooseShippingMethod
     /**
      * @var mixed
      */
-    private $shippingIdentifier;
+    private $shipmentIdentifier;
 
     /**
      * @var string
@@ -21,13 +21,13 @@ final class ChooseShippingMethod
 
     /**
      * @param string $orderToken
-     * @param mixed$shippingIdentifier
+     * @param mixed $shipmentIdentifier
      * @param string $shippingMethod
      */
-    public function __construct($orderToken, $shippingIdentifier, $shippingMethod)
+    public function __construct($orderToken, $shipmentIdentifier, $shippingMethod)
     {
         $this->orderToken = $orderToken;
-        $this->shippingIdentifier = $shippingIdentifier;
+        $this->shipmentIdentifier = $shipmentIdentifier;
         $this->shippingMethod = $shippingMethod;
     }
 
@@ -42,9 +42,9 @@ final class ChooseShippingMethod
     /**
      * @return mixed
      */
-    public function shippingIdentifier()
+    public function shipmentIdentifier()
     {
-        return $this->shippingIdentifier;
+        return $this->shipmentIdentifier;
     }
 
     /**

--- a/src/Command/ChooseShippingMethod.php
+++ b/src/Command/ChooseShippingMethod.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Sylius\ShopApiPlugin\Command;
+
+final class ChooseShippingMethod
+{
+    /**
+     * @var mixed
+     */
+    private $shippingIdentifier;
+
+    /**
+     * @var string
+     */
+    private $shippingMethod;
+
+    /**
+     * @var string
+     */
+    private $orderToken;
+
+    /**
+     * @param string $orderToken
+     * @param mixed$shippingIdentifier
+     * @param string $shippingMethod
+     */
+    public function __construct($orderToken, $shippingIdentifier, $shippingMethod)
+    {
+        $this->orderToken = $orderToken;
+        $this->shippingIdentifier = $shippingIdentifier;
+        $this->shippingMethod = $shippingMethod;
+    }
+
+    /**
+     * @return string
+     */
+    public function orderToken()
+    {
+        return $this->orderToken;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function shippingIdentifier()
+    {
+        return $this->shippingIdentifier;
+    }
+
+    /**
+     * @return string
+     */
+    public function shippingMethod()
+    {
+        return $this->shippingMethod;
+    }
+}

--- a/src/Command/PickupCart.php
+++ b/src/Command/PickupCart.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Sylius\ShopApiPlugin\Command;
+
+final class PickupCart
+{
+    /**
+     * @var string
+     */
+    private $token;
+
+    /**
+     * @var string
+     */
+    private $channelCode;
+
+    /**
+     * @param string $token
+     * @param string $channelCode
+     */
+    public function __construct($token, $channelCode)
+    {
+        $this->token = $token;
+        $this->channelCode = $channelCode;
+    }
+
+    /**
+     * @return string
+     */
+    public function token()
+    {
+        return $this->token;
+    }
+
+    /**
+     * @return string
+     */
+    public function channelCode()
+    {
+        return $this->channelCode;
+    }
+}

--- a/src/Command/PutSimpleItemToCart.php
+++ b/src/Command/PutSimpleItemToCart.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Sylius\ShopApiPlugin\Command;
+
+final class PutSimpleItemToCart
+{
+    /**
+     * @var string
+     */
+    private $token;
+
+    /**
+     * @var string
+     */
+    private $product;
+
+    /**
+     * @var int
+     */
+    private $quantity;
+
+    /**
+     * @param string $token
+     * @param string $product
+     * @param int $quantity
+     */
+    public function __construct($token, $product, $quantity)
+    {
+        $this->token = $token;
+        $this->product = $product;
+        $this->quantity = $quantity;
+    }
+
+    /**
+     * @return string
+     */
+    public function token()
+    {
+        return $this->token;
+    }
+
+    /**
+     * @return string
+     */
+    public function product()
+    {
+        return $this->product;
+    }
+
+    /**
+     * @return int
+     */
+    public function quantity()
+    {
+        return $this->quantity;
+    }
+}

--- a/src/Controller/Checkout/ChooseShippingMethodAction.php
+++ b/src/Controller/Checkout/ChooseShippingMethodAction.php
@@ -5,12 +5,26 @@ namespace Sylius\ShopApiPlugin\Controller\Checkout;
 use FOS\RestBundle\View\View;
 use FOS\RestBundle\View\ViewHandlerInterface;
 use League\Tactician\CommandBus;
+use Sylius\Component\Core\Model\OrderInterface;
+use Sylius\Component\Core\Model\ShipmentInterface;
+use Sylius\Component\Core\Model\ShippingMethodInterface;
+use Sylius\Component\Core\Repository\OrderRepositoryInterface;
+use Sylius\Component\Registry\ServiceRegistryInterface;
+use Sylius\Component\Shipping\Calculator\CalculatorInterface;
+use Sylius\Component\Shipping\Resolver\ShippingMethodsResolverInterface;
+use Sylius\ShopApiPlugin\Builder\AddressViewFactoryInterface;
+use Sylius\ShopApiPlugin\Builder\CartViewFactoryInterface;
 use Sylius\ShopApiPlugin\Command\AddressOrder;
+use Sylius\ShopApiPlugin\Command\ChooseShippingMethod;
 use Sylius\ShopApiPlugin\Model\Address;
+use Sylius\ShopApiPlugin\View\AddressView;
+use Sylius\ShopApiPlugin\View\ShipmentMethodView;
+use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
-final class AddressAction
+final class ChooseShippingMethodAction
 {
     /**
      * @var ViewHandlerInterface
@@ -39,14 +53,10 @@ final class AddressAction
      */
     public function __invoke(Request $request)
     {
-        $this->bus->handle(new AddressOrder(
+        $this->bus->handle(new ChooseShippingMethod(
             $request->attributes->get('token'),
-            Address::createFromArray($request->request->get('shippingAddress')),
-            Address::createFromArray(
-                $request->request->has('billingAddress') ?
-                    $request->request->get('billingAddress') :
-                    $request->request->get('shippingAddress')
-            )
+            $request->attributes->get('shippingId'),
+            $request->request->get('method')
         ));
 
         return $this->viewHandler->handle(View::create(null, Response::HTTP_NO_CONTENT));

--- a/src/Controller/Checkout/ShowAvailableShippingMethodsAction.php
+++ b/src/Controller/Checkout/ShowAvailableShippingMethodsAction.php
@@ -28,7 +28,7 @@ final class ShowAvailableShippingMethodsAction
     private $viewHandler;
 
     /**
-     * @var ViewHandlerInterface
+     * @var ShippingMethodsResolverInterface
      */
     private $shippingMethodsResolver;
 

--- a/src/Controller/Checkout/ShowAvailableShippingMethodsAction.php
+++ b/src/Controller/Checkout/ShowAvailableShippingMethodsAction.php
@@ -1,0 +1,104 @@
+<?php
+
+namespace Sylius\ShopApiPlugin\Controller\Checkout;
+
+use FOS\RestBundle\View\View;
+use FOS\RestBundle\View\ViewHandlerInterface;
+use Sylius\Component\Core\Model\OrderInterface;
+use Sylius\Component\Core\Model\ShipmentInterface;
+use Sylius\Component\Core\Model\ShippingMethodInterface;
+use Sylius\Component\Core\Repository\OrderRepositoryInterface;
+use Sylius\Component\Registry\ServiceRegistryInterface;
+use Sylius\Component\Shipping\Calculator\CalculatorInterface;
+use Sylius\Component\Shipping\Resolver\ShippingMethodsResolverInterface;
+use Sylius\ShopApiPlugin\View\ShipmentMethodView;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+final class ShowAvailableShippingMethodsAction
+{
+    /**
+     * @var OrderRepositoryInterface
+     */
+    private $cartRepository;
+
+    /**
+     * @var ViewHandlerInterface
+     */
+    private $viewHandler;
+
+    /**
+     * @var ViewHandlerInterface
+     */
+    private $shippingMethodsResolver;
+
+    /**
+     * @var ServiceRegistryInterface
+     */
+    private $calculators;
+
+    /**
+     * @param OrderRepositoryInterface $cartRepository
+     * @param ViewHandlerInterface $viewHandler
+     * @param ShippingMethodsResolverInterface $shippingMethodsResolver
+     * @param ServiceRegistryInterface $calculators
+     */
+    public function __construct(
+        OrderRepositoryInterface $cartRepository,
+        ViewHandlerInterface $viewHandler,
+        ShippingMethodsResolverInterface $shippingMethodsResolver,
+        ServiceRegistryInterface $calculators
+    ) {
+        $this->cartRepository = $cartRepository;
+        $this->viewHandler = $viewHandler;
+        $this->shippingMethodsResolver = $shippingMethodsResolver;
+        $this->calculators = $calculators;
+    }
+
+    /**
+     * @param Request $request
+     *
+     * @return Response
+     */
+    public function __invoke(Request $request)
+    {
+        /** @var OrderInterface $cart */
+        $cart = $this->cartRepository->findOneBy(['tokenValue' => $request->attributes->get('token')]);
+
+        $shipments = [];
+
+        foreach ($cart->getShipments() as $shipment) {
+            $shipments['shipments'][] = $this->getCalculatedShippingMethods($shipment, $cart->getLocaleCode());
+        }
+
+        return $this->viewHandler->handle(View::create($shipments));
+    }
+
+    /**
+     * @param ShipmentInterface $shipment
+     * @param string $locale
+     *
+     * @return array
+     */
+    private function getCalculatedShippingMethods(ShipmentInterface $shipment, $locale)
+    {
+        $rawShippingMethods = [];
+
+        /** @var ShippingMethodInterface $shippingMethod */
+        foreach ($this->shippingMethodsResolver->getSupportedMethods($shipment) as $shippingMethod) {
+            /** @var CalculatorInterface $calculator */
+            $calculator = $this->calculators->get($shippingMethod->getCalculator());
+
+            $shippingMethodView = new ShipmentMethodView();
+
+            $shippingMethodView->code = $shippingMethod->getCode();
+            $shippingMethodView->name = $shippingMethod->getTranslation($locale)->getName();
+            $shippingMethodView->description = $shippingMethod->getTranslation($locale)->getDescription();
+            $shippingMethodView->price = $calculator->calculate($shipment, $shippingMethod->getConfiguration());
+
+            $rawShippingMethods[$shippingMethodView->code] = $shippingMethodView;
+        }
+
+        return $rawShippingMethods;
+    }
+}

--- a/src/Handler/ChooseShippingMethodHandler.php
+++ b/src/Handler/ChooseShippingMethodHandler.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace Sylius\ShopApiPlugin\Handler;
+
+use SM\Factory\FactoryInterface;
+use Sylius\Component\Core\Model\OrderInterface;
+use Sylius\Component\Core\OrderCheckoutTransitions;
+use Sylius\Component\Core\Repository\OrderRepositoryInterface;
+use Sylius\Component\Core\Repository\ShippingMethodRepositoryInterface;
+use Sylius\Component\Shipping\Checker\ShippingMethodEligibilityCheckerInterface;
+use Sylius\ShopApiPlugin\Command\ChooseShippingMethod;
+
+final class ChooseShippingMethodHandler
+{
+    /**
+     * @var OrderRepositoryInterface
+     */
+    private $orderRepository;
+
+    /**
+     * @var ShippingMethodRepositoryInterface
+     */
+    private $shippingMethodRepository;
+
+    /**
+     * @var ShippingMethodEligibilityCheckerInterface
+     */
+    private $eligibilityChecker;
+
+    /**
+     * @var FactoryInterface
+     */
+    private $stateMachineFactory;
+
+    /**
+     * @param OrderRepositoryInterface $orderRepository
+     * @param ShippingMethodRepositoryInterface $shippingMethodRepository
+     * @param ShippingMethodEligibilityCheckerInterface $eligibilityChecker
+     * @param FactoryInterface $stateMachineFactory
+     */
+    public function __construct(
+        OrderRepositoryInterface $orderRepository,
+        ShippingMethodRepositoryInterface $shippingMethodRepository,
+        ShippingMethodEligibilityCheckerInterface $eligibilityChecker,
+        FactoryInterface $stateMachineFactory
+    ) {
+        $this->orderRepository = $orderRepository;
+        $this->shippingMethodRepository = $shippingMethodRepository;
+        $this->eligibilityChecker = $eligibilityChecker;
+        $this->stateMachineFactory = $stateMachineFactory;
+    }
+
+    /**
+     * @param ChooseShippingMethod $chooseShippingMethod
+     *
+     * @throws \LogicException
+     */
+    public function handle(ChooseShippingMethod $chooseShippingMethod)
+    {
+        /** @var OrderInterface $order */
+        $order = $this->orderRepository->findOneBy(['tokenValue' => $chooseShippingMethod->orderToken()]);
+
+        if (null === $order) {
+            throw new \LogicException('Order has not been found');
+        }
+
+        $stateMachine = $this->stateMachineFactory->get($order, OrderCheckoutTransitions::GRAPH);
+
+        if (!$stateMachine->can(OrderCheckoutTransitions::TRANSITION_SELECT_SHIPPING)) {
+            throw new \LogicException('Order cannot have shipment method assigned');
+        }
+
+        $shippingMethod = $this->shippingMethodRepository->findOneBy(['code' => $chooseShippingMethod->shippingMethod()]);
+
+        if (null === $shippingMethod) {
+            throw new \LogicException('Shipping method has not been found');
+        }
+
+        if (!isset($order->getShipments()[$chooseShippingMethod->shippingIdentifier()])) {
+            throw new \LogicException('Shipping method has not been found');
+        }
+
+        $shipment = $order->getShipments()[$chooseShippingMethod->shippingIdentifier()];
+
+        if (!$this->eligibilityChecker->isEligible($shipment, $shippingMethod)) {
+            throw new \LogicException('Given shipment is not eligible for provided shipping method');
+        }
+
+        $shipment->setMethod($shippingMethod);
+        $stateMachine->apply(OrderCheckoutTransitions::TRANSITION_SELECT_SHIPPING);
+    }
+}

--- a/src/Handler/PickupCartHandler.php
+++ b/src/Handler/PickupCartHandler.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Sylius\ShopApiPlugin\Handler;
+
+use Sylius\Component\Channel\Repository\ChannelRepositoryInterface;
+use Sylius\Component\Core\Model\ChannelInterface;
+use Sylius\Component\Core\Model\OrderInterface;
+use Sylius\Component\Core\Repository\OrderRepositoryInterface;
+use Sylius\Component\Resource\Factory\FactoryInterface;
+use Sylius\ShopApiPlugin\Command\PickupCart;
+
+final class PickupCartHandler
+{
+    /**
+     * @var FactoryInterface
+     */
+    private $cartFactory;
+
+    /**
+     * @var OrderRepositoryInterface
+     */
+    private $cartRepository;
+
+    /**
+     * @var ChannelRepositoryInterface
+     */
+    private $channelRepository;
+
+    /**
+     * @param FactoryInterface $cartFactory
+     * @param OrderRepositoryInterface $cartRepository
+     * @param ChannelRepositoryInterface $channelRepository
+     */
+    public function __construct(FactoryInterface $cartFactory, OrderRepositoryInterface $cartRepository, ChannelRepositoryInterface $channelRepository)
+    {
+        $this->cartFactory = $cartFactory;
+        $this->cartRepository = $cartRepository;
+        $this->channelRepository = $channelRepository;
+    }
+
+    /**
+     * @param PickupCart $pickupCart
+     */
+    public function handle(PickupCart $pickupCart)
+    {
+        /** @var ChannelInterface $channel */
+        $channel = $this->channelRepository->findOneByCode($pickupCart->channelCode());
+
+        /** @var OrderInterface $cart */
+        $cart = $this->cartFactory->createNew();
+        $cart->setChannel($channel);
+        $cart->setCurrencyCode($channel->getBaseCurrency()->getCode());
+        $cart->setLocaleCode($channel->getDefaultLocale()->getCode());
+        $cart->setTokenValue($pickupCart->token());
+
+        $this->cartRepository->add($cart);
+    }
+}

--- a/src/Handler/PutSimpleItemToCartHandler.php
+++ b/src/Handler/PutSimpleItemToCartHandler.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace Sylius\ShopApiPlugin\Handler;
+
+use Sylius\Component\Core\Factory\CartItemFactoryInterface;
+use Sylius\Component\Core\Model\OrderItemInterface;
+use Sylius\Component\Core\Model\ProductInterface;
+use Sylius\Component\Core\Repository\OrderRepositoryInterface;
+use Sylius\Component\Core\Repository\ProductRepositoryInterface;
+use Sylius\Component\Order\Modifier\OrderItemQuantityModifierInterface;
+use Sylius\Component\Order\Processor\OrderProcessorInterface;
+use Sylius\ShopApiPlugin\Command\PutSimpleItemToCart;
+
+final class PutSimpleItemToCartHandler
+{
+    /**
+     * @var OrderRepositoryInterface
+     */
+    private $cartRepository;
+
+    /**
+     * @var ProductRepositoryInterface
+     */
+    private $productRepository;
+
+    /**
+     * @var CartItemFactoryInterface
+     */
+    private $cartItemFactory;
+
+    /**
+     * @var OrderItemQuantityModifierInterface
+     */
+    private $orderItemModifier;
+
+    /**
+     * @var OrderProcessorInterface
+     */
+    private $orderProcessor;
+
+    /**
+     * @param OrderRepositoryInterface $cartRepository
+     * @param ProductRepositoryInterface $productRepository
+     * @param CartItemFactoryInterface $cartItemFactory
+     * @param OrderItemQuantityModifierInterface $orderItemModifier
+     * @param OrderProcessorInterface $orderProcessor
+     */
+    public function __construct(
+        OrderRepositoryInterface $cartRepository,
+        ProductRepositoryInterface $productRepository,
+        CartItemFactoryInterface $cartItemFactory,
+        OrderItemQuantityModifierInterface $orderItemModifier,
+        OrderProcessorInterface $orderProcessor
+    ) {
+        $this->cartRepository = $cartRepository;
+        $this->productRepository = $productRepository;
+        $this->cartItemFactory = $cartItemFactory;
+        $this->orderItemModifier = $orderItemModifier;
+        $this->orderProcessor = $orderProcessor;
+    }
+
+    public function handle(PutSimpleItemToCart $putSimpleItemToCart)
+    {
+        $cart = $this->cartRepository->findOneBy(['tokenValue' => $putSimpleItemToCart->token()]);
+
+        /** @var ProductInterface $product */
+        $product = $this->productRepository->findOneBy(['code' => $putSimpleItemToCart->product()]);
+
+        $productVariant = $product->getVariants()[0];
+
+        /** @var OrderItemInterface $cartItem */
+        $cartItem = $this->cartItemFactory->createForCart($cart);
+        $cartItem->setVariant($productVariant);
+        $this->orderItemModifier->modify($cartItem, $putSimpleItemToCart->quantity());
+
+        $cart->addItem($cartItem);
+
+        $this->orderProcessor->process($cart);
+    }
+}

--- a/src/Handler/PutSimpleItemToCartHandler.php
+++ b/src/Handler/PutSimpleItemToCartHandler.php
@@ -11,6 +11,7 @@ use Sylius\Component\Core\Repository\ProductRepositoryInterface;
 use Sylius\Component\Order\Modifier\OrderItemQuantityModifierInterface;
 use Sylius\Component\Order\Processor\OrderProcessorInterface;
 use Sylius\ShopApiPlugin\Command\PutSimpleItemToCart;
+use Webmozart\Assert\Assert;
 
 final class PutSimpleItemToCartHandler
 {
@@ -72,8 +73,12 @@ final class PutSimpleItemToCartHandler
     {
         $cart = $this->cartRepository->findOneBy(['tokenValue' => $putSimpleItemToCart->token()]);
 
+        Assert::notNull($cart, 'Cart has not been found');
+
         /** @var ProductInterface $product */
         $product = $this->productRepository->findOneBy(['code' => $putSimpleItemToCart->product()]);
+
+        Assert::notNull($product, 'Product has not been found');
 
         $productVariant = $product->getVariants()[0];
 

--- a/src/Handler/PutSimpleItemToCartHandler.php
+++ b/src/Handler/PutSimpleItemToCartHandler.php
@@ -2,6 +2,7 @@
 
 namespace Sylius\ShopApiPlugin\Handler;
 
+use Doctrine\Common\Persistence\ObjectManager;
 use Sylius\Component\Core\Factory\CartItemFactoryInterface;
 use Sylius\Component\Core\Model\OrderItemInterface;
 use Sylius\Component\Core\Model\ProductInterface;
@@ -39,24 +40,32 @@ final class PutSimpleItemToCartHandler
     private $orderProcessor;
 
     /**
+     * @var ObjectManager
+     */
+    private $manager;
+
+    /**
      * @param OrderRepositoryInterface $cartRepository
      * @param ProductRepositoryInterface $productRepository
      * @param CartItemFactoryInterface $cartItemFactory
      * @param OrderItemQuantityModifierInterface $orderItemModifier
      * @param OrderProcessorInterface $orderProcessor
+     * @param ObjectManager $manager
      */
     public function __construct(
         OrderRepositoryInterface $cartRepository,
         ProductRepositoryInterface $productRepository,
         CartItemFactoryInterface $cartItemFactory,
         OrderItemQuantityModifierInterface $orderItemModifier,
-        OrderProcessorInterface $orderProcessor
+        OrderProcessorInterface $orderProcessor,
+        ObjectManager $manager
     ) {
         $this->cartRepository = $cartRepository;
         $this->productRepository = $productRepository;
         $this->cartItemFactory = $cartItemFactory;
         $this->orderItemModifier = $orderItemModifier;
         $this->orderProcessor = $orderProcessor;
+        $this->manager = $manager;
     }
 
     public function handle(PutSimpleItemToCart $putSimpleItemToCart)
@@ -76,5 +85,7 @@ final class PutSimpleItemToCartHandler
         $cart->addItem($cartItem);
 
         $this->orderProcessor->process($cart);
+
+        $this->manager->persist($cart);
     }
 }

--- a/src/Resources/config/routing/checkout.yml
+++ b/src/Resources/config/routing/checkout.yml
@@ -9,3 +9,15 @@ shop_api_summarize_checkout:
     methods: [GET]
     defaults:
         _controller: sylius.shop_api_plugin.controller.checkout.summarize_action
+
+shop_api_available_shipping_checkout:
+    path: /{token}/shipping
+    methods: [GET]
+    defaults:
+        _controller: sylius.shop_api_plugin.controller.checkout.show_available_shipping_methods_action
+
+shop_api_choose_shipping_method:
+    path: /{token}/shipping/{shippingId}
+    methods: [PUT]
+    defaults:
+        _controller: sylius.shop_api_plugin.controller.checkout.choose_shipping_method_action

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -43,6 +43,20 @@
             <argument type="service" id="sm.factory"/>
             <tag name="tactician.handler" command="Sylius\ShopApiPlugin\Command\AddressOrder"/>
         </service>
+        <service id="sylius.shop_api_plugin.handler.pickup_cart_handler" class="Sylius\ShopApiPlugin\Handler\PickupCartHandler">
+            <argument type="service" id="sylius.factory.order"/>
+            <argument type="service" id="sylius.repository.order"/>
+            <argument type="service" id="sylius.repository.channel"/>
+            <tag name="tactician.handler" command="Sylius\ShopApiPlugin\Command\PickupCart"/>
+        </service>
+        <service id="sylius.shop_api_plugin.handler.put_simple_item_to_cart_handler" class="Sylius\ShopApiPlugin\Handler\PutSimpleItemToCartHandler">
+            <argument type="service" id="sylius.repository.order"/>
+            <argument type="service" id="sylius.repository.product"/>
+            <argument type="service" id="sylius.factory.order_item"/>
+            <argument type="service" id="sylius.order_item_quantity_modifier"/>
+            <argument type="service" id="sylius.order_processing.order_processor"/>
+            <tag name="tactician.handler" command="Sylius\ShopApiPlugin\Command\PutSimpleItemToCart"/>
+        </service>
 
         <!-- TODO: Should be removed when problem with autostarting session will be resolved -->
         <service id="sylius.listener.session_cart" class="Sylius\Bundle\CoreBundle\EventListener\SessionCartSubscriber">

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -55,7 +55,15 @@
             <argument type="service" id="sylius.factory.order_item"/>
             <argument type="service" id="sylius.order_item_quantity_modifier"/>
             <argument type="service" id="sylius.order_processing.order_processor"/>
+            <argument type="service" id="sylius.manager.order"/>
             <tag name="tactician.handler" command="Sylius\ShopApiPlugin\Command\PutSimpleItemToCart"/>
+        </service>
+        <service id="sylius.shop_api_plugin.handler.choose_shipping_method_handler" class="Sylius\ShopApiPlugin\Handler\ChooseShippingMethodHandler">
+            <argument type="service" id="sylius.repository.order"/>
+            <argument type="service" id="sylius.repository.shipping_method"/>
+            <argument type="service" id="sylius.shipping_eligibility_checker"/>
+            <argument type="service" id="sm.factory"/>
+            <tag name="tactician.handler" command="Sylius\ShopApiPlugin\Command\ChooseShippingMethod"/>
         </service>
 
         <!-- TODO: Should be removed when problem with autostarting session will be resolved -->

--- a/src/Resources/config/services/controller.xml
+++ b/src/Resources/config/services/controller.xml
@@ -7,12 +7,30 @@
             <argument type="service" id="fos_rest.view_handler" />
             <argument type="service" id="sylius.shop_api_plugin.factory.taxon_view_factory" />
         </service>
-        <service id="sylius.shop_api_plugin.controller.checkout.summarize_action" class="Sylius\ShopApiPlugin\Controller\Checkout\SummarizeAction">
+        <service id="sylius.shop_api_plugin.controller.checkout.summarize_action"
+                 class="Sylius\ShopApiPlugin\Controller\Checkout\SummarizeAction"
+        >
             <argument type="service" id="sylius.repository.order" />
             <argument type="service" id="fos_rest.view_handler" />
             <argument type="service" id="sylius.shop_api_plugin.factory.cart_view_factory" />
         </service>
-        <service id="sylius.shop_api_plugin.controller.checkout.address_action" class="Sylius\ShopApiPlugin\Controller\Checkout\AddressAction">
+        <service id="sylius.shop_api_plugin.controller.checkout.address_action"
+                 class="Sylius\ShopApiPlugin\Controller\Checkout\AddressAction"
+        >
+            <argument type="service" id="fos_rest.view_handler" />
+            <argument type="service" id="tactician.commandbus" />
+        </service>
+        <service id="sylius.shop_api_plugin.controller.checkout.show_available_shipping_methods_action"
+                 class="Sylius\ShopApiPlugin\Controller\Checkout\ShowAvailableShippingMethodsAction"
+        >
+            <argument type="service" id="sylius.repository.order" />
+            <argument type="service" id="fos_rest.view_handler" />
+            <argument type="service" id="sylius.shipping_methods_resolver" />
+            <argument type="service" id="sylius.registry.shipping_calculator" />
+        </service>
+        <service id="sylius.shop_api_plugin.controller.checkout.choose_shipping_method_action"
+                 class="Sylius\ShopApiPlugin\Controller\Checkout\ChooseShippingMethodAction"
+        >
             <argument type="service" id="fos_rest.view_handler" />
             <argument type="service" id="tactician.commandbus" />
         </service>

--- a/src/View/ShipmentMethodView.php
+++ b/src/View/ShipmentMethodView.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Sylius\ShopApiPlugin\View;
+
+class ShipmentMethodView
+{
+    /**
+     * @var string
+     */
+    public $code;
+
+    /**
+     * @var string
+     */
+    public $name;
+
+    /**
+     * @var string
+     */
+    public $description;
+
+    /**
+     * @var int
+     */
+    public $price;
+}

--- a/tests/Application/app/config/config.yml
+++ b/tests/Application/app/config/config.yml
@@ -1,5 +1,5 @@
 parameters:
-    locale: en_US
+    locale: en_GB
     secret: "Heron is the best animal in the world!"
 
 imports:

--- a/tests/Controller/CheckoutAddressShopApiTest.php
+++ b/tests/Controller/CheckoutAddressShopApiTest.php
@@ -3,6 +3,9 @@
 namespace Tests\Sylius\ShopApiPlugin\Controller;
 
 use Lakion\ApiTestCase\JsonApiTestCase;
+use League\Tactician\CommandBus;
+use Sylius\ShopApiPlugin\Command\PickupCart;
+use Sylius\ShopApiPlugin\Command\PutSimpleItemToCart;
 use Symfony\Component\HttpFoundation\Response;
 
 final class CheckoutAddressShopApiTest extends JsonApiTestCase
@@ -26,8 +29,10 @@ final class CheckoutAddressShopApiTest extends JsonApiTestCase
 
         $token = 'SDAOSLEFNWU35H3QLI5325';
 
-        $this->pickupCart($token, 'WEB_GB');
-        $this->putItemToCart($token);
+        /** @var CommandBus $bus */
+        $bus = $this->get('tactician.commandbus');
+        $bus->handle(new PickupCart($token, 'WEB_GB'));
+        $bus->handle(new PutSimpleItemToCart($token, 'LOGAN_MUG_CODE', 5));
 
         $data =
 <<<EOT
@@ -59,8 +64,10 @@ EOT;
 
         $token = 'SDAOSLEFNWU35H3QLI5325';
 
-        $this->pickupCart($token, 'WEB_GB');
-        $this->putItemToCart($token);
+        /** @var CommandBus $bus */
+        $bus = $this->get('tactician.commandbus');
+        $bus->handle(new PickupCart($token, 'WEB_GB'));
+        $bus->handle(new PutSimpleItemToCart($token, 'LOGAN_MUG_CODE', 5));
 
         $data =
 <<<EOT
@@ -91,8 +98,10 @@ EOT;
 
         $token = 'SDAOSLEFNWU35H3QLI5325';
 
-        $this->pickupCart($token, 'WEB_GB');
-        $this->putItemToCart($token);
+        /** @var CommandBus $bus */
+        $bus = $this->get('tactician.commandbus');
+        $bus->handle(new PickupCart($token, 'WEB_GB'));
+        $bus->handle(new PutSimpleItemToCart($token, 'LOGAN_MUG_CODE', 5));
 
         $data =
 <<<EOT
@@ -122,35 +131,5 @@ EOT;
 
         $response = $this->client->getResponse();
         $this->assertResponseCode($response, Response::HTTP_NO_CONTENT);
-    }
-
-    /**
-     * @param string $token
-     */
-    private function pickupCart($token, $channelCode)
-    {
-        $data =
-<<<EOT
-        {
-            "channel": "$channelCode"
-        }
-EOT;
-
-        $this->client->request('POST', '/shop-api/carts/' . $token, [], [], static::$acceptAndContentTypeHeader, $data);
-    }
-
-    /**
-     * @param string $token
-     */
-    private function putItemToCart($token)
-    {
-        $data =
-<<<EOT
-        {
-            "productCode": "LOGAN_MUG_CODE",
-            "quantity": 5
-        }
-EOT;
-        $this->client->request('POST', sprintf('/shop-api/carts/%s/items', $token), [], [], static::$acceptAndContentTypeHeader, $data);
     }
 }

--- a/tests/Controller/CheckoutChooseShippingMethodApiTest.php
+++ b/tests/Controller/CheckoutChooseShippingMethodApiTest.php
@@ -23,65 +23,6 @@ final class CheckoutChooseShippingMethodApiTest extends JsonApiTestCase
     /**
      * @test
      */
-    public function it_provides_details_about_available_shipping_method()
-    {
-        $this->loadFixturesFromFile('shop.yml');
-        $this->loadFixturesFromFile('country.yml');
-        $this->loadFixturesFromFile('shipping.yml');
-
-        $token = 'SDAOSLEFNWU35H3QLI5325';
-
-        /** @var CommandBus $bus */
-        $bus = $this->get('tactician.commandbus');
-        $bus->handle(new PickupCart($token, 'WEB_GB'));
-        $bus->handle(new PutSimpleItemToCart($token, 'LOGAN_MUG_CODE', 5));
-        $bus->handle(new AddressOrder(
-            $token,
-            Address::createFromArray([
-                'firstName' => 'Sherlock',
-                'lastName' => 'Holmes',
-                'city' => 'London',
-                'street' => 'Baker Street 221b',
-                'countryCode' => 'GB',
-                'postcode' => 'NWB',
-                'provinceName' => 'Greater London',
-            ]), Address::createFromArray([
-                'firstName' => 'Sherlock',
-                'lastName' => 'Holmes',
-                'city' => 'London',
-                'street' => 'Baker Street 221b',
-                'countryCode' => 'GB',
-                'postcode' => 'NWB',
-                'provinceName' => 'Greater London',
-            ])
-        ));
-
-        $this->client->request('GET', $this->getShippingUrl($token));
-
-        $response = $this->client->getResponse();
-        $this->assertResponse($response, 'checkout/get_available_shipping_methods', Response::HTTP_OK);
-    }
-
-    public function it_does_not_provide_details_about_available_shipping_method_before_addressing()
-    {
-        $this->loadFixturesFromFile('shop.yml');
-
-        $token = 'SDAOSLEFNWU35H3QLI5325';
-
-        /** @var CommandBus $bus */
-        $bus = $this->get('tactician.commandbus');
-        $bus->handle(new PickupCart($token, 'WEB_GB'));
-        $bus->handle(new PutSimpleItemToCart($token, 'LOGAN_MUG_CODE', 5));
-
-        $this->client->request('GET', $this->getShippingUrl($token), [], []);
-
-        $response = $this->client->getResponse();
-        $this->assertResponse($response, 'checkout/get_available_shipping_methods_failed', Response::HTTP_BAD_REQUEST);
-    }
-
-    /**
-     * @test
-     */
     public function it_allows_to_choose_shipping_method()
     {
         $this->loadFixturesFromFile('shop.yml');

--- a/tests/Controller/CheckoutChooseShippingMethodApiTest.php
+++ b/tests/Controller/CheckoutChooseShippingMethodApiTest.php
@@ -1,0 +1,140 @@
+<?php
+
+namespace Tests\Sylius\ShopApiPlugin\Controller;
+
+use Lakion\ApiTestCase\JsonApiTestCase;
+use League\Tactician\CommandBus;
+use Sylius\ShopApiPlugin\Command\AddressOrder;
+use Sylius\ShopApiPlugin\Command\PickupCart;
+use Sylius\ShopApiPlugin\Command\PutSimpleItemToCart;
+use Sylius\ShopApiPlugin\Model\Address;
+use Symfony\Component\HttpFoundation\Response;
+
+final class CheckoutChooseShippingMethodApiTest extends JsonApiTestCase
+{
+    public function it_does_not_provide_details_about_available_shipping_method_for_unexisting_cart()
+    {
+        $this->client->request('GET', $this->getShippingUrl(0), [], []);
+
+        $response = $this->client->getResponse();
+        $this->assertResponseCode($response, Response::HTTP_NOT_FOUND);
+    }
+
+    /**
+     * @test
+     */
+    public function it_provides_details_about_available_shipping_method()
+    {
+        $this->loadFixturesFromFile('shop.yml');
+        $this->loadFixturesFromFile('country.yml');
+        $this->loadFixturesFromFile('shipping.yml');
+
+        $token = 'SDAOSLEFNWU35H3QLI5325';
+
+        /** @var CommandBus $bus */
+        $bus = $this->get('tactician.commandbus');
+        $bus->handle(new PickupCart($token, 'WEB_GB'));
+        $bus->handle(new PutSimpleItemToCart($token, 'LOGAN_MUG_CODE', 5));
+        $bus->handle(new AddressOrder(
+            $token,
+            Address::createFromArray([
+                'firstName' => 'Sherlock',
+                'lastName' => 'Holmes',
+                'city' => 'London',
+                'street' => 'Baker Street 221b',
+                'countryCode' => 'GB',
+                'postcode' => 'NWB',
+                'provinceName' => 'Greater London',
+            ]), Address::createFromArray([
+                'firstName' => 'Sherlock',
+                'lastName' => 'Holmes',
+                'city' => 'London',
+                'street' => 'Baker Street 221b',
+                'countryCode' => 'GB',
+                'postcode' => 'NWB',
+                'provinceName' => 'Greater London',
+            ])
+        ));
+
+        $this->client->request('GET', $this->getShippingUrl($token));
+
+        $response = $this->client->getResponse();
+        $this->assertResponse($response, 'checkout/get_available_shipping_methods', Response::HTTP_OK);
+    }
+
+    public function it_does_not_provide_details_about_available_shipping_method_before_addressing()
+    {
+        $this->loadFixturesFromFile('shop.yml');
+
+        $token = 'SDAOSLEFNWU35H3QLI5325';
+
+        /** @var CommandBus $bus */
+        $bus = $this->get('tactician.commandbus');
+        $bus->handle(new PickupCart($token, 'WEB_GB'));
+        $bus->handle(new PutSimpleItemToCart($token, 'LOGAN_MUG_CODE', 5));
+
+        $this->client->request('GET', $this->getShippingUrl($token), [], []);
+
+        $response = $this->client->getResponse();
+        $this->assertResponse($response, 'checkout/get_available_shipping_methods_failed', Response::HTTP_BAD_REQUEST);
+    }
+
+    /**
+     * @test
+     */
+    public function it_allows_to_choose_shipping_method()
+    {
+        $this->loadFixturesFromFile('shop.yml');
+        $this->loadFixturesFromFile('country.yml');
+        $this->loadFixturesFromFile('shipping.yml');
+
+        $token = 'SDAOSLEFNWU35H3QLI5325';
+
+        /** @var CommandBus $bus */
+        $bus = $this->get('tactician.commandbus');
+        $bus->handle(new PickupCart($token, 'WEB_GB'));
+        $bus->handle(new PutSimpleItemToCart($token, 'LOGAN_MUG_CODE', 5));
+        $bus->handle(new AddressOrder(
+            $token,
+            Address::createFromArray([
+                'firstName' => 'Sherlock',
+                'lastName' => 'Holmes',
+                'city' => 'London',
+                'street' => 'Baker Street 221b',
+                'countryCode' => 'GB',
+                'postcode' => 'NWB',
+                'provinceName' => 'Greater London',
+            ]), Address::createFromArray([
+                'firstName' => 'Sherlock',
+                'lastName' => 'Holmes',
+                'city' => 'London',
+                'street' => 'Baker Street 221b',
+                'countryCode' => 'GB',
+                'postcode' => 'NWB',
+                'provinceName' => 'Greater London',
+            ])
+        ));
+
+        $data =
+<<<EOT
+        {
+            "method": "DHL"
+        }
+EOT;
+
+        $this->client->request('PUT', $this->getShippingUrl($token) . '/0', [], [], ['CONTENT_TYPE' => 'application/json', 'ACCEPT' => 'application/json'], $data);
+
+        $response = $this->client->getResponse();
+        $this->assertResponseCode($response, Response::HTTP_NO_CONTENT);
+    }
+
+    /**
+     * @param string $token
+     *
+     * @return string
+     */
+    private function getShippingUrl($token)
+    {
+        return sprintf('/shop-api/checkout/%s/shipping', $token);
+    }
+}

--- a/tests/Controller/CheckoutShowAvailableShippingMethodsShopApiTest.php
+++ b/tests/Controller/CheckoutShowAvailableShippingMethodsShopApiTest.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace Tests\Sylius\ShopApiPlugin\Controller;
+
+use Lakion\ApiTestCase\JsonApiTestCase;
+use League\Tactician\CommandBus;
+use Sylius\ShopApiPlugin\Command\AddressOrder;
+use Sylius\ShopApiPlugin\Command\PickupCart;
+use Sylius\ShopApiPlugin\Command\PutSimpleItemToCart;
+use Sylius\ShopApiPlugin\Model\Address;
+use Symfony\Component\HttpFoundation\Response;
+
+final class CheckoutShowAvailableShippingMethodsShopApiTest extends JsonApiTestCase
+{
+    public function it_does_not_provide_details_about_available_shipping_method_for_unexisting_cart()
+    {
+        $this->client->request('GET', $this->getShippingUrl(0), [], []);
+
+        $response = $this->client->getResponse();
+        $this->assertResponseCode($response, Response::HTTP_NOT_FOUND);
+    }
+
+    /**
+     * @test
+     */
+    public function it_provides_details_about_available_shipping_method()
+    {
+        $this->loadFixturesFromFile('shop.yml');
+        $this->loadFixturesFromFile('country.yml');
+        $this->loadFixturesFromFile('shipping.yml');
+
+        $token = 'SDAOSLEFNWU35H3QLI5325';
+
+        /** @var CommandBus $bus */
+        $bus = $this->get('tactician.commandbus');
+        $bus->handle(new PickupCart($token, 'WEB_GB'));
+        $bus->handle(new PutSimpleItemToCart($token, 'LOGAN_MUG_CODE', 5));
+        $bus->handle(new AddressOrder(
+            $token,
+            Address::createFromArray([
+                'firstName' => 'Sherlock',
+                'lastName' => 'Holmes',
+                'city' => 'London',
+                'street' => 'Baker Street 221b',
+                'countryCode' => 'GB',
+                'postcode' => 'NWB',
+                'provinceName' => 'Greater London',
+            ]), Address::createFromArray([
+                'firstName' => 'Sherlock',
+                'lastName' => 'Holmes',
+                'city' => 'London',
+                'street' => 'Baker Street 221b',
+                'countryCode' => 'GB',
+                'postcode' => 'NWB',
+                'provinceName' => 'Greater London',
+            ])
+        ));
+
+        $this->client->request('GET', $this->getShippingUrl($token));
+
+        $response = $this->client->getResponse();
+        $this->assertResponse($response, 'checkout/get_available_shipping_methods', Response::HTTP_OK);
+    }
+
+    public function it_does_not_provide_details_about_available_shipping_method_before_addressing()
+    {
+        $this->loadFixturesFromFile('shop.yml');
+
+        $token = 'SDAOSLEFNWU35H3QLI5325';
+
+        /** @var CommandBus $bus */
+        $bus = $this->get('tactician.commandbus');
+        $bus->handle(new PickupCart($token, 'WEB_GB'));
+        $bus->handle(new PutSimpleItemToCart($token, 'LOGAN_MUG_CODE', 5));
+
+        $this->client->request('GET', $this->getShippingUrl($token), [], []);
+
+        $response = $this->client->getResponse();
+        $this->assertResponse($response, 'checkout/get_available_shipping_methods_failed', Response::HTTP_BAD_REQUEST);
+    }
+
+    /**
+     * @param string $token
+     *
+     * @return string
+     */
+    private function getShippingUrl($token)
+    {
+        return sprintf('/shop-api/checkout/%s/shipping', $token);
+    }
+}

--- a/tests/Controller/CheckoutSummarizeShopApiTest.php
+++ b/tests/Controller/CheckoutSummarizeShopApiTest.php
@@ -3,6 +3,9 @@
 namespace Tests\Sylius\ShopApiPlugin\Controller;
 
 use Lakion\ApiTestCase\JsonApiTestCase;
+use League\Tactician\CommandBus;
+use Sylius\ShopApiPlugin\Command\PickupCart;
+use Sylius\ShopApiPlugin\Command\PutSimpleItemToCart;
 use Symfony\Component\HttpFoundation\Response;
 
 final class CheckoutSummarizeShopApiTest extends JsonApiTestCase
@@ -18,8 +21,10 @@ final class CheckoutSummarizeShopApiTest extends JsonApiTestCase
 
         $token = 'SDAOSLEFNWU35H3QLI5325';
 
-        $this->pickupCart($token, 'WEB_GB');
-        $this->putItemToCart($token);
+        /** @var CommandBus $bus */
+        $bus = $this->get('tactician.commandbus');
+        $bus->handle(new PickupCart($token, 'WEB_GB'));
+        $bus->handle(new PutSimpleItemToCart($token, 'LOGAN_MUG_CODE', 5));
 
         $data =
 <<<EOT
@@ -53,8 +58,10 @@ EOT;
 
         $token = 'SDAOSLEFNWU35H3QLI5325';
 
-        $this->pickupCart($token, 'WEB_GB');
-        $this->putItemToCart($token);
+        /** @var CommandBus $bus */
+        $bus = $this->get('tactician.commandbus');
+        $bus->handle(new PickupCart($token, 'WEB_GB'));
+        $bus->handle(new PutSimpleItemToCart($token, 'LOGAN_MUG_CODE', 5));
 
         $data =
 <<<EOT
@@ -86,36 +93,5 @@ EOT;
 
         $response = $this->client->getResponse();
         $this->assertResponse($response, 'checkout/cart_addressed_with_different_shipping_and_billing_address_response', Response::HTTP_OK);
-    }
-
-
-    /**
-     * @param string $token
-     */
-    private function pickupCart($token, $channelCode)
-    {
-        $data =
-<<<EOT
-        {
-            "channel": "$channelCode"
-        }
-EOT;
-
-        $this->client->request('POST', '/shop-api/carts/' . $token, [], [], static::$acceptAndContentTypeHeader, $data);
-    }
-
-    /**
-     * @param string $token
-     */
-    private function putItemToCart($token)
-    {
-        $data =
-<<<EOT
-        {
-            "productCode": "LOGAN_MUG_CODE",
-            "quantity": 5
-        }
-EOT;
-        $this->client->request('POST', sprintf('/shop-api/carts/%s/items', $token), [], [], static::$acceptAndContentTypeHeader, $data);
     }
 }

--- a/tests/Responses/Expected/checkout/get_available_shipping_methods.json
+++ b/tests/Responses/Expected/checkout/get_available_shipping_methods.json
@@ -1,0 +1,12 @@
+{
+    "shipments": [
+        {
+            "DHL": {
+                "code": "DHL",
+                "name": "DHL",
+                "description": "@string@",
+                "price": 1500
+            }
+        }
+    ]
+}


### PR DESCRIPTION
Resolves #21 and #19

Based on #64 

There is a slight change in a choosing request. Instead of `PUT /cart/{token}/select-shipping` with the following body: 
```json
{
    "shipments": [
        {
            "method": "DELIVERY_CODE"
        }
    ]
}
```
I have decide for `PUT /cart/{token}/shipping/{shippingId}` with
```json
{
    "method": "DELIVERY_CODE"
}
```