### PR TITLE
[Maintenance] Drop PHP 5.6 and PHP 7.0 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,6 @@ language: php
 
 php:
     - 7.1
-    - 7.0
-    - 5.6
 
 cache:
     directories:

--- a/composer.json
+++ b/composer.json
@@ -7,6 +7,7 @@
         "php": "^5.6|^7.0",
 
         "sylius/sylius": "^1.0.0@beta",
+        "symfony/symfony": "~3.2, <3.3",
         "league/tactician-bundle": "~0.4",
         "league/tactician-doctrine": "^1.1"
     },

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "description": "Shop API for Sylius E-Commerce.",
     "license": "MIT",
     "require": {
-        "php": "^5.6|^7.0",
+        "php": "^7.1",
 
         "sylius/sylius": "^1.0.0@beta",
         "symfony/symfony": "~3.2, <3.3",

--- a/tests/Application/app/config/config.yml
+++ b/tests/Application/app/config/config.yml
@@ -27,7 +27,6 @@ framework:
     validation: { enabled: true }
     templating: { engines: ["twig"] }
     default_locale: "%locale%"
-    trusted_proxies: ~
     session:
         storage_id: session.storage.mock_file
         handler_id: ~


### PR DESCRIPTION
Just a first commit from #140. Too many things happen there, it will be easier to do it step by step.

Based on #142 