### PR TITLE
[Cart] More consistent validation message

### DIFF
--- a/src/Request/PutOptionBasedConfigurableItemToCartRequest.php
+++ b/src/Request/PutOptionBasedConfigurableItemToCartRequest.php
@@ -15,7 +15,7 @@ final class PutOptionBasedConfigurableItemToCartRequest
     /**
      * @var string
      */
-    private $product;
+    private $productCode;
 
     /**
      * @var array|null
@@ -33,7 +33,7 @@ final class PutOptionBasedConfigurableItemToCartRequest
     public function __construct(Request $request)
     {
         $this->token = $request->attributes->get('token');
-        $this->product = $request->request->get('productCode');
+        $this->productCode = $request->request->get('productCode');
         $this->options = $request->request->get('options');
         $this->quantity = $request->request->getInt('quantity');
     }
@@ -43,6 +43,6 @@ final class PutOptionBasedConfigurableItemToCartRequest
      */
     public function getCommand()
     {
-        return new PutOptionBasedConfigurableItemToCart($this->token, $this->product, $this->options, $this->quantity);
+        return new PutOptionBasedConfigurableItemToCart($this->token, $this->productCode, $this->options, $this->quantity);
     }
 }

--- a/src/Request/PutSimpleItemToCartRequest.php
+++ b/src/Request/PutSimpleItemToCartRequest.php
@@ -15,7 +15,7 @@ final class PutSimpleItemToCartRequest
     /**
      * @var string
      */
-    private $product;
+    private $productCode;
 
     /**
      * @var int
@@ -28,7 +28,7 @@ final class PutSimpleItemToCartRequest
     public function __construct(Request $request)
     {
         $this->token = $request->attributes->get('token');
-        $this->product = $request->request->get('productCode');
+        $this->productCode = $request->request->get('productCode');
         $this->quantity = $request->request->get('quantity');
     }
 
@@ -37,6 +37,6 @@ final class PutSimpleItemToCartRequest
      */
     public function getCommand()
     {
-        return new PutSimpleItemToCart($this->token, $this->product, $this->quantity);
+        return new PutSimpleItemToCart($this->token, $this->productCode, $this->quantity);
     }
 }

--- a/src/Request/PutVariantBasedConfigurableItemToCartRequest.php
+++ b/src/Request/PutVariantBasedConfigurableItemToCartRequest.php
@@ -15,12 +15,12 @@ final class PutVariantBasedConfigurableItemToCartRequest
     /**
      * @var string
      */
-    private $product;
+    private $productCode;
 
     /**
      * @var string
      */
-    private $variant;
+    private $variantCode;
 
     /**
      * @var int
@@ -33,8 +33,8 @@ final class PutVariantBasedConfigurableItemToCartRequest
     public function __construct(Request $request)
     {
         $this->token = $request->attributes->get('token');
-        $this->product = $request->request->get('productCode');
-        $this->variant = $request->request->get('variantCode');
+        $this->productCode = $request->request->get('productCode');
+        $this->variantCode = $request->request->get('variantCode');
         $this->quantity = $request->request->get('quantity');
     }
 
@@ -43,6 +43,6 @@ final class PutVariantBasedConfigurableItemToCartRequest
      */
     public function getCommand()
     {
-        return new PutVariantBasedConfigurableItemToCart($this->token, $this->product, $this->variant, $this->quantity);
+        return new PutVariantBasedConfigurableItemToCart($this->token, $this->productCode, $this->variantCode, $this->quantity);
     }
 }

--- a/src/Resources/config/validation/PutSimpleItemToCartRequest.xml
+++ b/src/Resources/config/validation/PutSimpleItemToCartRequest.xml
@@ -34,7 +34,7 @@
                 <option name="message">sylius.shop_api.quantity.not_null</option>
             </constraint>
         </property>
-        <property name="product">
+        <property name="productCode">
             <constraint name="NotNull">
                 <option name="message">sylius.shop_api.product.not_null</option>
             </constraint>

--- a/src/Resources/config/validation/PutVariantBasedConfigutableItemToCartRequest.xml
+++ b/src/Resources/config/validation/PutVariantBasedConfigutableItemToCartRequest.xml
@@ -34,14 +34,14 @@
                 <option name="message">sylius.shop_api.quantity.not_null</option>
             </constraint>
         </property>
-        <property name="product">
+        <property name="productCode">
             <constraint name="NotNull">
                 <option name="message">sylius.shop_api.product.not_null</option>
             </constraint>
             <constraint name="Sylius\ShopApiPlugin\Validator\Constraints\ProductExists" />
             <constraint name="Sylius\ShopApiPlugin\Validator\Constraints\ConfigurableProduct" />
         </property>
-        <property name="variant">
+        <property name="variantCode">
             <constraint name="NotNull">
                 <option name="message">sylius.shop_api.product.not_null</option>
             </constraint>

--- a/tests/Responses/Expected/cart/validation_product_not_configurable_response.json
+++ b/tests/Responses/Expected/cart/validation_product_not_configurable_response.json
@@ -2,7 +2,7 @@
     "code": 400,
     "message": "Validation failed",
     "errors": {
-        "product": [
+        "productCode": [
             "sylius.shop_api.product.configurable"
         ]
     }

--- a/tests/Responses/Expected/cart/validation_product_not_defined_response.json
+++ b/tests/Responses/Expected/cart/validation_product_not_defined_response.json
@@ -2,7 +2,7 @@
     "code": 400,
     "message": "Validation failed",
     "errors": {
-        "product": [
+        "productCode": [
             "sylius.shop_api.product.not_null",
             "sylius.shop_api.product.exists"
         ]

--- a/tests/Responses/Expected/cart/validation_product_not_exists_response.json
+++ b/tests/Responses/Expected/cart/validation_product_not_exists_response.json
@@ -2,7 +2,7 @@
     "code": 400,
     "message": "Validation failed",
     "errors": {
-        "product": [
+        "productCode": [
             "sylius.shop_api.product.exists"
         ]
     }

--- a/tests/Responses/Expected/cart/validation_product_not_simple_response.json
+++ b/tests/Responses/Expected/cart/validation_product_not_simple_response.json
@@ -2,7 +2,7 @@
     "code": 400,
     "message": "Validation failed",
     "errors": {
-        "product": [
+        "productCode": [
             "sylius.shop_api.product.simple"
         ]
     }

--- a/tests/Responses/Expected/cart/validation_product_variant_not_exists_response.json
+++ b/tests/Responses/Expected/cart/validation_product_variant_not_exists_response.json
@@ -2,7 +2,7 @@
     "code": 400,
     "message": "Validation failed",
     "errors": {
-        "variant": [
+        "variantCode": [
             "sylius.shop_api.product_variant.exists"
         ]
     }


### PR DESCRIPTION
We should also think about unifying keys between requests. Sometimes I have used `channel` sometimes `channelCode` for example. It should be fixed before release 