### PR TITLE
[Config] Make firewalls name more coherent

### DIFF
--- a/tests/Application/app/config/security.yml
+++ b/tests/Application/app/config/security.yml
@@ -53,7 +53,7 @@ security:
             stateless:  true
             anonymous:  true
 
-        shop-api-login:
+        shop_api_login:
             pattern:  "%shop_api.security.regex%/login"
             stateless: true
             anonymous: true


### PR DESCRIPTION
Rest of firewalls names have hard spaces instead of dashes 