### PR TITLE
Exclude doctrine/common >=2.8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "matthiasnoback/symfony-config-test": "^2.0",
         "matthiasnoback/symfony-dependency-injection-test": "^1.0",
         "phpunit/phpunit": "^5.6",
-        "symfony/symfony": "~3.2, <3.3"
+        "doctrine/common": "<2.8"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Too strict final class policy makes tests failing.