### PR TITLE
fix nelmio_cors bundle config in the readme, 

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ Rest of the command are executed inside `project` folder.
             paths:
                 '^/shop-api/':
                     allow_origin: ['*']
-                    allow_headers: ['X-Custom-Auth']
+                    allow_headers: ['Content-Type']
                     allow_methods: ['POST', 'PUT', 'GET', 'DELETE']
                     max_age: 3600
                 '^/':


### PR DESCRIPTION
with this fix, it works for the add-to-cart post API on localhost with regular JSON payload, which doesn't need to be FormData

related to this issue https://github.com/nelmio/NelmioCorsBundle/issues/37