### PR TITLE
update nelmio_cors config,

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,16 +152,9 @@ Rest of the command are executed inside `project` folder.
             paths:
                 '^/shop-api/':
                     allow_origin: ['*']
-                    allow_headers: ['Content-Type']
-                    allow_methods: ['POST', 'PUT', 'GET', 'DELETE']
+                    allow_headers: ['Content-Type', 'authorization']
+                    allow_methods: ['POST', 'PUT', 'GET', 'DELETE', 'OPTIONS']
                     max_age: 3600
-                '^/':
-                    origin_regex: true
-                    allow_origin: ['^http://localhost:[0-9]+']
-                    allow_headers: ['X-Custom-Auth']
-                    allow_methods: ['POST', 'PUT', 'GET', 'DELETE']
-                    max_age: 3600
-                    hosts: ['^api\.']
         ```
 
 ## Additional features


### PR DESCRIPTION
add allowed header authorization and allowed method options

need to permit cors preflight options, otherwise the JWT token could not be sent along the request like `/shop-api/me`, get always an 'Unauthorized header' error