### PR TITLE
Fix an issue in the configuration example which causes error in loading checkout page.

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ Rest of the command are executed inside `project` folder.
 
     sylius_shop:
         checkout_resolver:
-            pattern: "%sylius.security.shop_regex%/checkout/"
+            pattern: "%sylius.security.shop_regex%/checkout/.+"
     ```
     
     6. (optional) if you have installed `nelmio/NelmioCorsBundle` for Support of Cross-Origin Ajax Request,


### PR DESCRIPTION
The CheckoutResolver should only be applied to the subpath of checkout, it would causes error in loading the root checkout path if enabled.