### PR TITLE
New Feature: populate the token parameter automatically when authentication is enabled for the APIs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,16 @@ In order to check example configuration check
  
 From the test app.
 
+### Cart Token with Authentication
+
+When authentication is enabled for the APIs, for example with [LexikJWTAuthenticationBundle](https://github.com/lexik/LexikJWTAuthenticationBundle), the cart token parameter could be populated automatically instead of passing the value through parameter. For URLs that have the token value e.g. `/carts/{token}`, you could simply put a placeholder there e.g. `/carts/placehoder`, the placeholder will be replaced automatically underneath with the authenticated user's default cart.
+
+Add the following config to enable this feature:
+```yml
+shop_api:
+    auto_pickup_cart: true
+```
+
 ## Testing
 
 The application can be tested with API Test Case. In order to run test suite execute the following command:

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -20,6 +20,7 @@ final class Configuration implements ConfigurationInterface
         $rootNode = $treeBuilder->root('shop_api');
 
         $this->buildIncludedAttributesNode($rootNode);
+        $this->buildAutoPickupCartNode($rootNode);
         $this->buildViewClassesNode($rootNode);
 
         return $treeBuilder;
@@ -31,6 +32,17 @@ final class Configuration implements ConfigurationInterface
             ->children()
                 ->arrayNode('included_attributes')
                     ->prototype('scalar')->end()
+                ->end()
+            ->end()
+        ;
+    }
+
+    private function buildAutoPickupCartNode(ArrayNodeDefinition $rootNode): void
+    {
+        $rootNode
+            ->children()
+                ->booleanNode('auto_pickup_cart')
+                    ->defaultFalse()
                 ->end()
             ->end()
         ;

--- a/src/EventListener/InteractiveLoginListener.php
+++ b/src/EventListener/InteractiveLoginListener.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sylius\ShopApiPlugin\EventListener;
+
+use Doctrine\Common\Persistence\ObjectManager;
+use Sylius\Component\Core\Model\OrderInterface;
+use Sylius\Component\Core\Model\ShopUserInterface;
+use Sylius\Component\Order\Context\CartContextInterface;
+use Sylius\Component\Order\Context\CartNotFoundException;
+use Sylius\Component\Resource\Exception\UnexpectedTypeException;
+use Symfony\Component\Security\Http\Event\InteractiveLoginEvent;
+
+final class InteractiveLoginListener
+{
+    /**
+     * @var ObjectManager
+     */
+    private $cartManager;
+
+    /**
+     * @var CartContextInterface
+     */
+    private $cartContext;
+
+    /**
+     * @param ObjectManager $cartManager
+     * @param CartContextInterface $cartContext
+     */
+    public function __construct(ObjectManager $cartManager, CartContextInterface $cartContext)
+    {
+        $this->cartManager = $cartManager;
+        $this->cartContext = $cartContext;
+    }
+
+    /**
+     * @param InteractiveLoginEvent $interactiveLoginEvent
+     */
+    public function onInteractiveLogin(InteractiveLoginEvent $interactiveLoginEvent): void
+    {
+        // Skip if it's not a shop API request.
+        if (!preg_match('/^shop_api_/', $interactiveLoginEvent->getRequest()->attributes->get('_route'))) {
+            return;
+        }
+
+        $user = $interactiveLoginEvent->getAuthenticationToken()->getUser();
+        if (!$user instanceof ShopUserInterface) {
+            return;
+        }
+
+        $cart = $this->getCart();
+        if (null === $cart) {
+            return;
+        }
+
+        if (null === $cart->getTokenValue()) {
+            // Generate a hash
+            $tokenValue = md5($user->getId() . $cart->getId() . time());
+
+            $cart->setTokenValue($tokenValue);
+            $this->cartManager->persist($cart);
+            $this->cartManager->flush();
+        }
+
+        $interactiveLoginEvent->getRequest()->attributes->set('token', $cart->getTokenValue());
+    }
+
+    /**
+     * @return OrderInterface|null
+     *
+     * @throws UnexpectedTypeException
+     */
+    private function getCart(): ?OrderInterface
+    {
+        try {
+            $cart = $this->cartContext->getCart();
+        } catch (CartNotFoundException $exception) {
+            return null;
+        }
+
+        if (!$cart instanceof OrderInterface) {
+            throw new UnexpectedTypeException($cart, OrderInterface::class);
+        }
+
+        return $cart;
+    }
+}


### PR DESCRIPTION
The idea is to find the cart automatically for logged in users. The key of this change is to assign a token value to the user's cart if it's not there, and use this value to populate the "token" parameter for any following requests.

Therefore, we don't have to pass the token value as a parameter explicitly. I have also added the instruction in the README doc, I'm using this feature for my application. Any feedback is welcome.