### PR TITLE
Drop support for Sylius 1.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,8 @@ php:
     - 7.2
 
 env:
-    - SYLIUS_VERSION=1.0.*
     - SYLIUS_VERSION=1.1.*
-    - SYLIUS_VERSION=1.2.*@beta
+    - SYLIUS_VERSION=1.2.*@rc
 
 cache:
     directories:

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "require": {
         "php": "^7.1",
 
-        "sylius/sylius": "^1.0",
+        "sylius/sylius": "^1.1",
         "league/tactician-bundle": "^0.4",
         "league/tactician-doctrine": "^1.1"
     },


### PR DESCRIPTION
Sylius 1.0 is about to stop being supported in a few days (only receiving security fixes).