### PR TITLE
[WIP] Payments

### DIFF
--- a/spec/Payment/InstructionResolverSpec.php
+++ b/spec/Payment/InstructionResolverSpec.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace spec\Sylius\ShopApiPlugin\Payment;
+
+use Payum\Core\Model\GatewayConfigInterface;
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+use Sylius\Component\Core\Model\PaymentInterface;
+use Sylius\Component\Core\Model\PaymentMethodInterface;
+use Sylius\ShopApiPlugin\Payment\Instruction;
+use Sylius\ShopApiPlugin\Payment\InstructionResolver;
+use Sylius\ShopApiPlugin\Payment\InstructionResolverInterface;
+
+class InstructionResolverSpec extends ObjectBehavior
+{
+    function it_is_initializable()
+    {
+        $this->shouldHaveType(InstructionResolver::class);
+    }
+
+    function it_implements_instruction_resolver_interface()
+    {
+        $this->shouldImplement(InstructionResolverInterface::class);
+    }
+
+    function it_returns_text_content_for_offline_payments(
+        PaymentInterface $payment,
+        PaymentMethodInterface $method,
+        GatewayConfigInterface $gatewayConfig
+    ) {
+        $payment->getMethod()->willReturn($method);
+        $method->getGatewayConfig()->willReturn($gatewayConfig);
+        $method->getInstructions()->willReturn('Please make bank transfer to PL1234 1234 1234 1234.');
+        $gatewayConfig->getFactoryName()->willReturn(InstructionResolverInterface::GATEWAY_OFFLINE);
+
+        $expectedInstruction = new Instruction();
+        $expectedInstruction->gateway = InstructionResolverInterface::GATEWAY_OFFLINE;
+        $expectedInstruction->type = InstructionResolverInterface::TYPE_TEXT;
+        $expectedInstruction->content = 'Please make bank transfer to PL1234 1234 1234 1234.';
+
+        $this->getInstruction($payment)->shouldBeLike($expectedInstruction);
+    }
+
+    function it_throws_an_exception_when_method_is_not_set(
+        PaymentInterface $payment
+    ) {
+        $payment->getMethod()->willReturn(null);
+
+        $this
+            ->shouldThrow(new \InvalidArgumentException('Payment method is not set.'))
+            ->during('getInstruction', [$payment])
+        ;
+    }
+}

--- a/src/Controller/Order/GetPaymentInstructionAction.php
+++ b/src/Controller/Order/GetPaymentInstructionAction.php
@@ -11,11 +11,9 @@ use Payum\Core\Model\GatewayConfigInterface;
 use Payum\Core\Payum;
 use Payum\Core\Request\Capture;
 use Payum\Core\Request\Generic;
-use Payum\Core\Request\GetStatusInterface;
 use Payum\Core\Security\GenericTokenFactoryInterface;
 use Payum\Core\Security\HttpRequestVerifierInterface;
 use Payum\Core\Security\TokenInterface;
-use Sylius\Bundle\PayumBundle\Factory\GetStatusFactoryInterface;
 use Sylius\Component\Core\Model\OrderInterface;
 use Sylius\Component\Core\Model\PaymentInterface;
 use Sylius\Component\Core\Model\PaymentMethodInterface;
@@ -46,19 +44,14 @@ final class GetPaymentInstructionAction
      */
     private $viewHandler;
 
-    /** @var GetStatusFactoryInterface */
-    private $getStatusRequestFactory;
-
     public function __construct(
         Payum $payum,
         OrderRepositoryInterface $orderRepository,
-        ViewHandlerInterface $viewHandler,
-        GetStatusFactoryInterface $getStatusFactory
+        ViewHandlerInterface $viewHandler
     ) {
         $this->payum = $payum;
         $this->orderRepository = $orderRepository;
         $this->viewHandler = $viewHandler;
-        $this->getStatusRequestFactory = $getStatusFactory;
     }
 
     public function __invoke(Request $request): Response

--- a/src/Controller/Order/GetPaymentInstructionAction.php
+++ b/src/Controller/Order/GetPaymentInstructionAction.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sylius\ShopApiPlugin\Controller\Order;
+
+use FOS\RestBundle\View\View;
+use FOS\RestBundle\View\ViewHandlerInterface;
+use League\Tactician\CommandBus;
+use Payum\Core\Model\GatewayConfigInterface;
+use Payum\Core\Payum;
+use Payum\Core\Request\Generic;
+use Payum\Core\Request\GetStatusInterface;
+use Payum\Core\Security\GenericTokenFactoryInterface;
+use Payum\Core\Security\HttpRequestVerifierInterface;
+use Payum\Core\Security\TokenInterface;
+use Sylius\Bundle\PayumBundle\Factory\GetStatusFactoryInterface;
+use Sylius\Component\Core\Model\OrderInterface;
+use Sylius\Component\Core\Model\PaymentInterface;
+use Sylius\Component\Core\Model\PaymentMethodInterface;
+use Sylius\Component\Order\Repository\OrderRepositoryInterface;
+use Sylius\ShopApiPlugin\Factory\ValidationErrorViewFactoryInterface;
+use Sylius\ShopApiPlugin\Request\RegisterCustomerRequest;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\Session\Flash\FlashBagInterface;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
+
+final class GetPaymentInstructionAction
+{
+    /**
+     * @var Payum
+     */
+    private $payum;
+
+    /**
+     * @var OrderRepositoryInterface
+     */
+    private $orderRepository;
+
+    /**
+     * @var ViewHandlerInterface
+     */
+    private $viewHandler;
+
+    /** @var GetStatusFactoryInterface */
+    private $getStatusRequestFactory;
+
+    public function __construct(
+        Payum $payum,
+        OrderRepositoryInterface $orderRepository,
+        ViewHandlerInterface $viewHandler,
+        GetStatusFactoryInterface $getStatusFactory
+    ) {
+        $this->payum = $payum;
+        $this->orderRepository = $orderRepository;
+        $this->viewHandler = $viewHandler;
+        $this->getStatusRequestFactory = $getStatusFactory;
+    }
+
+    public function __invoke(Request $request): Response
+    {
+        $token = $request->attributes->get('token');
+
+        /** @var OrderInterface $order */
+        $order = $this->orderRepository->findOneByTokenValue($token);
+
+        if (null === $order) {
+            throw new NotFoundHttpException(sprintf('Order with token "%s" does not exist.', $token));
+        }
+
+        $payment = $order->getLastPayment(PaymentInterface::STATE_NEW);
+
+        if (null === $payment) {
+            throw new \LogicException(sprintf('Order with token "%s" does not have any "new" payments.', $token));
+        }
+
+        $method = $payment->getMethod();
+        $gatewayConfig = $method->getGatewayConfig();
+
+        $token = $this->provideTokenBasedOnPayment($payment);
+        $view = View::create([
+            'method' => $gatewayConfig->getGatewayName(),
+            'type' => 'text',
+            'content' => $method->getInstructions(),
+        ]);
+
+        return $this->viewHandler->handle($view);
+    }
+
+    private function provideTokenBasedOnPayment(PaymentInterface $payment): TokenInterface
+    {
+        $method = $payment->getMethod();
+        $gatewayConfig = $method->getGatewayConfig();
+
+        $token = $this->getTokenFactory()->createCaptureToken(
+            $gatewayConfig->getGatewayName(),
+            $payment,
+            'sylius_shop_homepage'
+        );
+
+        return $token;
+    }
+
+    private function getTokenFactory(): GenericTokenFactoryInterface
+    {
+        return $this->payum->getTokenFactory();
+    }
+}

--- a/src/Payment/Instruction.php
+++ b/src/Payment/Instruction.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sylius\ShopApiPlugin\Payment;
+
+class Instruction
+{
+    public $method;
+    public $type;
+    public $content = [];
+}

--- a/src/Payment/InstructionResolver.php
+++ b/src/Payment/InstructionResolver.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sylius\ShopApiPlugin\Payment;
+
+use Sylius\Component\Core\Model\PaymentInterface;
+
+class InstructionResolver implements InstructionResolverInterface
+{
+    final public function getInstruction(PaymentInterface $payment) : Instruction
+    {
+        $method = $payment->getMethod();
+
+        if (null === $method) {
+            throw new \InvalidArgumentException('Payment method is not set.');
+        }
+
+        $gatewayConfig = $method->getGatewayConfig();
+
+        $instruction = new Instruction();
+        $instruction->gateway = InstructionResolverInterface::GATEWAY_OFFLINE;
+        $instruction->type = InstructionResolverInterface::TYPE_TEXT;
+        $instruction->content = $method->getInstructions();
+
+        return $instruction;
+    }
+}

--- a/src/Payment/InstructionResolverInterface.php
+++ b/src/Payment/InstructionResolverInterface.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sylius\ShopApiPlugin\Payment;
+
+use Sylius\Component\Core\Model\PaymentInterface;
+
+interface InstructionResolverInterface
+{
+    const GATEWAY_OFFLINE = 'offline';
+    const GATEWAY_HPP = 'hosted_payment_page';
+
+    const TYPE_TEXT = 'text';
+    const TYPE_REDIRECT = 'redirect';
+
+    public function getInstruction(PaymentInterface $payment) : Instruction;
+}

--- a/src/Resources/config/routing.yml
+++ b/src/Resources/config/routing.yml
@@ -22,6 +22,10 @@ sylius_shop_api_checkout:
     resource: "@ShopApiPlugin/Resources/config/routing/checkout.yml"
     prefix: /shop-api/checkout
 
+sylius_shop_api_order:
+    resource: "@ShopApiPlugin/Resources/config/routing/order.yml"
+    prefix: /shop-api/order
+
 sylius_shop_api_customer:
     resource: "@ShopApiPlugin/Resources/config/routing/customer.yml"
     prefix: /shop-api

--- a/src/Resources/config/routing/order.yml
+++ b/src/Resources/config/routing/order.yml
@@ -1,0 +1,5 @@
+sylius_shop_api_order_payment_instruction:
+    path: /{token}/payment-instruction
+    methods: [GET]
+    defaults:
+        _controller: sylius.shop_api_plugin.controller.order.payment_instruction_action

--- a/src/Resources/config/services/actions/order.xml
+++ b/src/Resources/config/services/actions/order.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+    <services>
+        <defaults public="true" />
+
+        <service id="sylius.shop_api_plugin.controller.order.payment_instruction_action"
+                 class="Sylius\ShopApiPlugin\Controller\Order\GetPaymentInstructionAction"
+        >
+            <argument type="service" id="payum" />
+            <argument type="service" id="sylius.repository.order" />
+            <argument type="service" id="fos_rest.view_handler" />
+            <argument type="service" id="sylius.factory.payum_get_status_action" />
+        </service>
+    </services>
+</container>

--- a/src/Resources/config/services/controllers.xml
+++ b/src/Resources/config/services/controllers.xml
@@ -3,6 +3,7 @@
 <container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
     <imports>
         <import resource="actions/checkout.xml"/>
+        <import resource="actions/order.xml"/>
         <import resource="actions/cart.xml"/>
         <import resource="actions/product.xml"/>
         <import resource="actions/customer.xml"/>

--- a/tests/Controller/OrderPaymentApiTest.php
+++ b/tests/Controller/OrderPaymentApiTest.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Sylius\ShopApiPlugin\Controller;
+
+use League\Tactician\CommandBus;
+use Sylius\ShopApiPlugin\Command\AddressOrder;
+use Sylius\ShopApiPlugin\Command\ChoosePaymentMethod;
+use Sylius\ShopApiPlugin\Command\ChooseShippingMethod;
+use Sylius\ShopApiPlugin\Command\PickupCart;
+use Sylius\ShopApiPlugin\Command\PutSimpleItemToCart;
+use Sylius\ShopApiPlugin\Command\CompleteOrder;
+use Sylius\ShopApiPlugin\Model\Address;
+use Symfony\Component\HttpFoundation\Response;
+
+final class OrderPaymentApiTest extends JsonApiTestCase
+{
+    /**
+     * @test
+     */
+    public function it_displays_payment_instructions_for_offline_payment()
+    {
+        $this->loadFixturesFromFiles(['shop.yml', 'country.yml', 'shipping.yml', 'payment.yml']);
+
+        $token = 'SDAOSLEFNWU35H3QLI5325';
+
+        /** @var CommandBus $bus */
+        $bus = $this->get('tactician.commandbus');
+        $bus->handle(new PickupCart($token, 'WEB_GB'));
+        $bus->handle(new PutSimpleItemToCart($token, 'LOGAN_MUG_CODE', 5));
+        $bus->handle(new AddressOrder(
+            $token,
+            Address::createFromArray([
+                'firstName' => 'Sherlock',
+                'lastName' => 'Holmes',
+                'city' => 'London',
+                'street' => 'Baker Street 221b',
+                'countryCode' => 'GB',
+                'postcode' => 'NWB',
+                'provinceName' => 'Greater London',
+            ]), Address::createFromArray([
+                'firstName' => 'Sherlock',
+                'lastName' => 'Holmes',
+                'city' => 'London',
+                'street' => 'Baker Street 221b',
+                'countryCode' => 'GB',
+                'postcode' => 'NWB',
+                'provinceName' => 'Greater London',
+            ])
+        ));
+
+        $bus->handle(new ChooseShippingMethod($token, 0, 'DHL'));
+        $bus->handle(new ChoosePaymentMethod($token, 0, 'PBC'));
+        $bus->handle(new CompleteOrder($token, "shop@example.com"));
+
+        $this->client->request('GET', sprintf('/shop-api/order/%s/payment-instruction', $token), [], [], [
+            'ACCEPT' => 'application/json',
+        ]);
+
+        $response = $this->client->getResponse();
+        $this->assertResponse($response, 'order/payment_instruction_offline', Response::HTTP_OK);
+    }
+}

--- a/tests/DataFixtures/ORM/payment.yml
+++ b/tests/DataFixtures/ORM/payment.yml
@@ -11,12 +11,25 @@ Sylius\Component\Core\Model\PaymentMethod:
         gatewayConfig: '@offline'
         currentLocale: "en_GB"
         channels: ["@gb_web_channel"]
+    pay_by_paypal:
+        code: "paypal"
+        enabled: true
+        gatewayConfig: '@paypal'
+        currentLocale: "en_GB"
+        channels: ["@gb_web_channel"]
 
 Sylius\Bundle\PayumBundle\Model\GatewayConfig:
     offline:
         gatewayName: 'Offline'
         factoryName: 'offline'
         config: []
+    paypal:
+        gatewayName: 'PayPal Express Checkout'
+        factoryName: 'paypal_express_checkout'
+        config:
+            username: "test"
+            password: "test"
+            signature: "test"
 
 Sylius\Component\Payment\Model\PaymentMethodTranslation:
     cash_on_delivery_translation:
@@ -30,3 +43,8 @@ Sylius\Component\Payment\Model\PaymentMethodTranslation:
         description: <paragraph(2)>
         instructions: "Please make bank transfer to: PL1234 1234 1234 1234."
         translatable: "@pay_by_check"
+    paypal_translation:
+        name: 'PayPal Express Checkout'
+        locale: 'en_GB'
+        description: <paragraph(2)>
+        translatable: "@pay_by_paypal"

--- a/tests/DataFixtures/ORM/payment.yml
+++ b/tests/DataFixtures/ORM/payment.yml
@@ -28,4 +28,5 @@ Sylius\Component\Payment\Model\PaymentMethodTranslation:
         name: 'Pay by check'
         locale: 'en_GB'
         description: <paragraph(2)>
+        instructions: "Please make bank transfer to: PL1234 1234 1234 1234."
         translatable: "@pay_by_check"

--- a/tests/Responses/Expected/order/payment_instruction_offline.json
+++ b/tests/Responses/Expected/order/payment_instruction_offline.json
@@ -1,0 +1,5 @@
+{
+    "method": "Offline",
+    "type": "text",
+    "content": "Please make bank transfer to: PL1234 1234 1234 1234."
+}

--- a/tests/Responses/Expected/order/payment_instruction_paypal.json
+++ b/tests/Responses/Expected/order/payment_instruction_paypal.json
@@ -1,0 +1,7 @@
+{
+    "method": "PayPal Express Checkout",
+    "type": "redirect",
+    "content": {
+        "url": "https://xxx"
+    }
+}


### PR DESCRIPTION
Hello!

Please bear with me, as I have not coded in a while. :D

This PR is an attempt to implement Payum on the API layer. So far I've implemented an action, that will return payment instructions in JSON, so that the frontend client (VUE.js/React/whatever) can act accordingly. In current production sites that use Sylius Headless, this is still handled by hitting Sylius instance directly to the standard urls. My goal with this PR is to make it possible to hide Sylius completely, as "ecommerce.xyz.com", so that "xyz.com" can handle the payment operations (post checkout) with API.

What do I need to finish this one?

1) Some help with how to obtain the proper redirect URL from Payum? I currently managed to get the target/after urls but these still point back to Sylius (I assume that's internal Payum thing), but I'd like to get the PayPal url, so that the frontend client can simply redirect the customer. (CC @makasim, Your help here would be priceless!)
2) Some feedback on the idea: I'd like to maybe implement the Strategy/Adapter Pattern, to react appropriately to specific gateway types (offline vs. redirect to Hosted Payment Page vs. token authorize like Stripe, etc.). The current implementation is a bit dirty, as I handle it in the controller directly and hardcode "Offline" use-case.
3) Regular code review. :)