### PR TITLE
Properly translate select attributes in shop API

### DIFF
--- a/src/Factory/Product/ProductAttributeValueViewFactory.php
+++ b/src/Factory/Product/ProductAttributeValueViewFactory.php
@@ -40,6 +40,16 @@ final class ProductAttributeValueViewFactory implements ProductAttributeValueVie
         $productAttributeTranslation = $productAttribute->getTranslation($localeCode);
         $productAttributeValueView->name = $productAttributeTranslation->getName();
 
+        if ($productAttribute && $productAttribute->getType() === 'select') {
+            $configuration = $productAttribute->getConfiguration();
+            $productAttributeValueView->value = array_map(
+                static function (string $value) use ($configuration, $locale) {
+                    return $configuration['choices'][$value][$locale];
+                },
+                $productAttributeValueView->value
+            );
+        }
+
         return $productAttributeValueView;
     }
 }


### PR DESCRIPTION
For select attributes, the translations set in the attribute configuration aren't used, but instead, the UUIDs are shown with no way for the user to fetch the real string. See below screenshot for an example:

![image](https://user-images.githubusercontent.com/1296821/90887945-ff505400-e3bd-11ea-8d3f-9940bb70f750.png)

This PR fixes this by specifically handling this case and retrieving the correct string for use in the API instead of the UUID.