### PR TITLE
[Maintenance] Allow flex plugin during plugin installation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -47,6 +47,11 @@
     "suggest": {
         "nelmio/cors-bundle": "allows you to send Cross-Origin Ajax API Request"
     },
+    "config": {
+        "allow-plugins": {
+            "symfony/flex": true
+        }
+    },
     "extra": {
         "branch-alias": {
             "dev-master": "1.0-dev"


### PR DESCRIPTION
Follow up of https://github.com/Sylius/Sylius/pull/14106